### PR TITLE
Added fix for Command and Conquer - Red Alert 2

### DIFF
--- a/gamefixes-steam/2229850.py
+++ b/gamefixes-steam/2229850.py
@@ -1,0 +1,41 @@
+""" Game fix for Command & Conquer Red Alert™ 2 and Yuri’s Revenge™
+"""
+#pylint: disable=C0103
+
+import os
+
+from protonfixes import util
+from protonfixes.logger import log
+
+def main():
+    """ Launch CnCNet Launcher - if installed, install it if requested
+
+        The game crashes, when the launcher and it's patches are installed
+        and Ra2.exe or RA2MD.exe are called directly by Steam.
+        For this reason we must always use the launcher, if present.
+
+        The game will just show a black screen without cnc-ddraw or the patch in place.
+    """
+
+    # User requested to install the CnCnet Launcher
+    if os.environ.get('INSTALL_CNCNET'):
+        log('User wants to install CnCnet Launcher')
+        util.protontricks('cncnet_ra2')
+
+    # CnCnet Launcher is in place, run it
+    if os.path.isfile('CnCNetYRLauncher.exe'):
+        log('CnCnet Launcher found, bypass game execution!')
+        util.replace_command('Ra2.exe', 'CnCNetYRLauncher.exe')
+        util.replace_command('RA2MD.exe', 'CnCNetYRLauncher.exe')
+    else:
+        # Return early, if cnc_ddraw is installed or failed to install
+        if not util.protontricks('cnc_ddraw'):
+            log('cnc-ddraw found!')
+            return
+
+        # After installing cnc_ddraw, we need to prevent the game
+        # from loading the local ddraw.dll, instead of our override.
+        # Note: This is only done once.
+        if os.path.isfile('ddraw.dll'):
+            log('Renaming local ddraw.dll to ddraw.dll.bak')
+            os.rename('ddraw.dll', 'ddraw.dll.bak')

--- a/gamefixes-steam/2229850.py
+++ b/gamefixes-steam/2229850.py
@@ -1,4 +1,4 @@
-""" Game fix for Command & Conquer Red Alert™ 2 and Yuri’s Revenge™
+""" Game fix for Command & Conquer Red Alert™ 2 and Yuri's Revenge™
 """
 #pylint: disable=C0103
 
@@ -8,34 +8,51 @@ from protonfixes import util
 from protonfixes.logger import log
 
 def main():
-    """ Launch CnCNet Launcher - if installed, install it if requested
+    """ Install and launch the CnCNet Launcher
 
-        The game crashes, when the launcher and it's patches are installed
-        and Ra2.exe or RA2MD.exe are called directly by Steam.
-        For this reason we must always use the launcher, if present.
+        It fixes several issues, allows multiplayer and provides a working UI,
+        while the game has sometimes problems like missing or shifted buttons.
 
         The game will just show a black screen without cnc-ddraw or the patch in place.
     """
 
-    # User requested to install the CnCnet Launcher
-    if os.environ.get('INSTALL_CNCNET'):
-        log('User wants to install CnCnet Launcher')
-        util.protontricks('cncnet_ra2')
+    # Opt out of CnCNet with 'NO_CNCNET=1 %command%'
+    no_cncnet = os.getenv('NO_CNCNET', '')
+    if str.lower(no_cncnet) in ['y', 'yes', 'true', 'on', '1']:
+        log('Skipping CnCNet on user\'s request.')
+        use_cnc_ddraw()
+        return
 
-    # CnCnet Launcher is in place, run it
+    # Install the CnCNet Launcher
+    if not util.checkinstalled('cncnet_ra2') and not util.protontricks('cncnet_ra2'):
+        log('Failed to install CnCNet Launcher, let\'s try cnc-ddraw.')
+        use_cnc_ddraw()
+
+    # CnCNet Launcher is in place, run it
     if os.path.isfile('CnCNetYRLauncher.exe'):
-        log('CnCnet Launcher found, bypass game execution!')
+        log('CnCNet Launcher found, bypass game execution!')
         util.replace_command('Ra2.exe', 'CnCNetYRLauncher.exe')
         util.replace_command('RA2MD.exe', 'CnCNetYRLauncher.exe')
-    else:
-        # Return early, if cnc_ddraw is installed or failed to install
-        if not util.protontricks('cnc_ddraw'):
-            log('cnc-ddraw found!')
-            return
 
-        # After installing cnc_ddraw, we need to prevent the game
-        # from loading the local ddraw.dll, instead of our override.
-        # Note: This is only done once.
-        if os.path.isfile('ddraw.dll'):
-            log('Renaming local ddraw.dll to ddraw.dll.bak')
-            os.rename('ddraw.dll', 'ddraw.dll.bak')
+def use_cnc_ddraw():
+    """ Install cnc-ddraw, the current replacement from EA isn't working.
+    """
+
+    log('Using cnc-ddraw.')
+
+    # Return early, if cnc-ddraw is installed
+    if util.checkinstalled('cnc_ddraw'):
+        log('cnc-ddraw found, nothing to do!')
+        return
+
+    # Install cnc-ddraw
+    if not util.protontricks('cnc_ddraw'):
+        log('Failed to install cnc-ddraw')
+        return
+
+    # After installing cnc_ddraw, we need to prevent the game
+    # from loading the local ddraw.dll, instead of our override.
+    # Note: This is only done once.
+    if os.path.isfile('ddraw.dll'):
+        log('Renaming local ddraw.dll to ddraw.dll.bak')
+        os.rename('ddraw.dll', 'ddraw.dll.bak')

--- a/verbs/cncnet_ra2.verb
+++ b/verbs/cncnet_ra2.verb
@@ -1,0 +1,13 @@
+w_metadata cncnet_ra2 dlls \
+    title="CnCnet5 Red Alert / Yuri's Revenge - Multiplayer / Game patches" \
+    publisher="CnCnet community" \
+    year="2013" \
+    media="download" \
+    file1="CnCNet5_YR_Installer.exe" \
+    installed_file1="CnCNetYRLauncher.exe"
+
+load_cncnet_ra2()
+{
+    w_download https://github.com/CnCNet/cncnet-yr-client-package/releases/download/yr-8.55/CnCNet5_YR_Installer_8.55.0.exe c1cf19fa40bb07e881ffeea33df8a5961162e009c558b33d91076f51ca3f949c ${file1}
+    w_try "${WINE}" start.exe /exec ${W_CACHE}/${W_PACKAGE}/${file1} /silent /verysilent /norestart /suppressmsgboxes
+}

--- a/winetricks
+++ b/winetricks
@@ -6068,7 +6068,7 @@ w_metadata cnc_ddraw dlls \
     publisher="CnCNet" \
     year="2021" \
     media="download" \
-    file1="cnc-ddraw-v6.2.0.0.zip" \
+    file1="cnc-ddraw-v6.3.0.0.zip" \
     installed_file1="${W_SYSTEM32_DLLS_WIN}/Shaders/readme.txt"
 
 load_cnc_ddraw()
@@ -6088,9 +6088,12 @@ load_cnc_ddraw()
     # 2023/11/04 https://github.com/FunkyFr3sh/cnc-ddraw/releases/download/v6.0.0.0/cnc-ddraw.zip
     # 2024/02/03 https://github.com/FunkyFr3sh/cnc-ddraw/releases/download/v6.1.0.0d/cnc-ddraw.zip
     # 2024/02/21 https://github.com/FunkyFr3sh/cnc-ddraw/releases/download/v6.2.0.0/cnc-ddraw.zip
+    # 2024/03/11 https://github.com/FunkyFr3sh/cnc-ddraw/releases/download/v6.3.0.0/cnc-ddraw.zip
 
-    w_download https://github.com/FunkyFr3sh/cnc-ddraw/releases/download/v6.2.0.0/cnc-ddraw.zip e5677ba52c31ffa93421a16edacff0c4d1f03e107aea6fc860861b43e3356119 cnc-ddraw-v6.2.0.0.zip
-    w_try_unzip "${W_SYSTEM32_DLLS}" "${W_CACHE}/${W_PACKAGE}/${file1}"
+    w_download https://github.com/FunkyFr3sh/cnc-ddraw/releases/download/v6.3.0.0/cnc-ddraw.zip c024d0ea42ec2d9708dc0a19342d037de7307c291dc43c01948a7d8f06b4deca ${file1}
+    w_try_unzip "${W_TMP}" "${W_CACHE}/${W_PACKAGE}/${file1}"
+    w_try_cp_dll "${W_TMP}/ddraw.dll" "${W_SYSTEM32_DLLS}/ddraw.dll"
+    w_try cp -R -u "${W_TMP}"/* "${W_SYSTEM32_DLLS}/"
 
     w_override_dlls native,builtin ddraw
 }


### PR DESCRIPTION
This fix has multiple purposes:

1. It fixes the black screen rendering issue.
2. It allows to install CnCnet Launcher and patches.
3. It runs the CnCnet Launcher, if installed.

I wasn't sure if it was okay to just install the Launcher without user consent. Therefore I implemented a toggle to request the installation. We could change this to default, the Launcher is de-facto the way to play the game these days.

I updated [cnc-ddraw in Winetricks](https://github.com/Winetricks/winetricks/pull/2199), but it isn't merged yet.
Feel free to cherry-pick.