### PR TITLE
fix audio for in-game videos (YOU and ME and HER - 1293820)

### DIFF
--- a/gamefixes-steam/1293820.py
+++ b/gamefixes-steam/1293820.py
@@ -11,3 +11,5 @@ def main():
     util.protontricks('xact')
     util.disable_esync()
     util.disable_fsync()
+    # Fixes audio not playing for in-game videos
+    util.disable_protonaudioconverter()


### PR DESCRIPTION
original fix did not allow audio to play during in-game videos. confirmed this fixes audio playback on proton-GE 9-2