### PR TITLE
Add XAudio 2.9 verb for Space Engineers

### DIFF
--- a/gamefixes-steam/244850.py
+++ b/gamefixes-steam/244850.py
@@ -7,6 +7,7 @@ from protonfixes import util
 
 
 def main():
+    util.protontricks('xaudio29')
 
     base_attibutte = "<runtime>"
     game_opts = """


### PR DESCRIPTION
Fixes some audio glitches in the latest versions.

Not yet part of any released winetricks version, but the embedded one includes it.