### PR TITLE
(Newest) Many WMP9 Video Playback fixes for Yuzusoft VN'sAdd files via upload

### DIFF
--- a/gamefixes-steam/1144400.py
+++ b/gamefixes-steam/1144400.py
@@ -1,0 +1,11 @@
+""" Game fix for Senren Banka
+"""
+#pylint: disable=C0103
+from protonfixes import util
+def main():
+    """
+    """
+    util.protontricks('quartz')
+    util.protontricks('wmp9')
+    util.protontricks('directshow')
+    util.disable_protonaudioconverter()

--- a/gamefixes-steam/1277930.py
+++ b/gamefixes-steam/1277930.py
@@ -1,0 +1,11 @@
+""" Game fix for Riddle Joker
+"""
+#pylint: disable=C0103
+from protonfixes import util
+def main():
+    """
+    """
+    util.protontricks('quartz')
+    util.protontricks('wmp9')
+    util.protontricks('directshow')
+    util.disable_protonaudioconverter()

--- a/gamefixes-steam/1829980.py
+++ b/gamefixes-steam/1829980.py
@@ -1,0 +1,11 @@
+""" Game fix for Cafe Stella
+"""
+#pylint: disable=C0103
+from protonfixes import util
+def main():
+    """
+    """
+    util.protontricks('quartz')
+    util.protontricks('wmp9')
+    util.protontricks('directshow')
+    util.disable_protonaudioconverter()

--- a/gamefixes-steam/2458530.py
+++ b/gamefixes-steam/2458530.py
@@ -1,0 +1,11 @@
+""" Game fix for Sanoba Witch FHD Edition
+"""
+#pylint: disable=C0103
+from protonfixes import util
+def main():
+    """
+    """
+    util.protontricks('quartz')
+    util.protontricks('wmp9')
+    util.protontricks('directshow')
+    util.disable_protonaudioconverter()

--- a/gamefixes-steam/888790.py
+++ b/gamefixes-steam/888790.py
@@ -1,0 +1,11 @@
+""" Game fix for Sabbat of the Witch
+"""
+#pylint: disable=C0103
+from protonfixes import util
+def main():
+    """
+    """
+    util.protontricks('quartz')
+    util.protontricks('wmp9')
+    util.protontricks('directshow')
+    util.disable_protonaudioconverter()


### PR DESCRIPTION
This will 100% fix WMP9 Video Playback for many Yuzusoft VN's, Including Riddle Joker. I am very certain this works, excluding even a single command will either cause a black screen, laggy or no audio or it just wont play. (I tested this very well) Reuploaded again to fix a tiny error, Only the Steam editions of these titles were tested and Full audio and video for FMV Scenes work. Other storefronts will most likely work considering there is no difference between versions (Trying WMP11 instead of WMP9 results in a black screen) I swear i will forfeit this whole project if there is a single mistake done, reuploading it with changes is getting really tiring