### PR TITLE
Add functionality to run commands in a sandbox

### DIFF
--- a/util.py
+++ b/util.py
@@ -290,7 +290,7 @@ def protontricks(verb: str) -> bool:
                     log.debug(str(sys.argv))
 
             # Make sure the cache exists
-            winetricks_cache = os.path.expanduser("~/.cache/winetricks") 
+            winetricks_cache = os.path.expanduser("~/.cache/winetricks")
             if not os.path.exists(winetricks_cache):
                 os.makedirs(winetricks_cache, exist_ok=True)
 

--- a/util.py
+++ b/util.py
@@ -897,8 +897,6 @@ def run_in_sandbox(cmd: list[str], env: dict[str, str]=None) -> int:
         ).returncode
 
     # Mount the root filesystem read-only except for the home directory
-    # The home directory will be invisible except the path to the WINE prefix,
-    # Proton, the game and winetricks cache directory
     for path in Path("/").glob("*"):
         if path.name != "home":
             posix_path = path.as_posix()

--- a/util.py
+++ b/util.py
@@ -858,11 +858,14 @@ def run_in_sandbox(cmd: list[str], env: dict[str, str]=None) -> int:
     """
     sandbox_bin = Path('/usr/libexec/steam-runtime-tools-0/srt-bwrap')
     env = env or dict(protonmain.g_session.env)
-    pfx = os.path.expanduser(os.environ.get("STEAM_COMPAT_DATA_PATH") or "")
-    proton = protondir()
-    game = get_game_install_path()
-    winetricks_cache = Path.home().joinpath(".cache", "winetricks").as_posix()
+    pfx = ""
+    proton = Path(protondir()).resolve().as_posix()
+    game = Path(get_game_install_path()).resolve().as_posix()
+    winetricks_cache = Path.home().joinpath(".cache", "winetricks").resolve().as_posix()
     rootfs = []
+
+    if os.environ.get("STEAM_COMPAT_DATA_PATH"):
+        pfx = Path(os.environ.get("STEAM_COMPAT_DATA_PATH")).resolve().as_posix()
 
     if not proton or not pfx:
         log.warn("WINEPREFIX or PROTONPATH is not set or empty")

--- a/util.py
+++ b/util.py
@@ -849,8 +849,9 @@ def run_in_sandbox(cmd: list[str], env: dict[str, str]=None) -> int:
     """
     sandbox_bin = '/usr/libexec/steam-runtime-tools-0/srt-bwrap'
     env = env or dict(protonmain.g_session.env)
-    pfx = os.path.expanduser(os.environ.get('WINEPREFIX') or "")
-    proton = os.path.expanduser(os.environ.get('PROTONPATH') or "")
+    pfx = protonprefix()
+    proton = protondir()
+    game = get_game_install_path()
 
     if not proton or not pfx:
         log.warn("WINEPREFIX or PROTONPATH is not set or empty")

--- a/util.py
+++ b/util.py
@@ -902,9 +902,7 @@ def run_in_sandbox(cmd: list[str], env: dict[str, str]=None) -> int:
     for path in Path("/").glob("*"):
         if path.name != "home":
             posix_path = path.as_posix()
-            rootfs.append("--ro-bind")
-            rootfs.append(posix_path)
-            rootfs.append(posix_path)
+            rootfs.extend(["--ro-bind", posix_path, posix_path])
 
     # Unshare all namespaces except the network
     opts = [

--- a/util.py
+++ b/util.py
@@ -883,7 +883,8 @@ def run_in_sandbox(cmd: list[str], env: dict[str, str]=None) -> int:
 
     # Mount the entire filesystem read-only and unshare all namespaces except
     # the network
-    # The paths /tmp, WINEPREFIX and PROTONPATH will be remounted read-write
+    # The path to the WINE prefix, Proton directory and the game directory
+    # will be remounted read-write
     opts = [
         '--ro-bind',
         '/',
@@ -906,6 +907,9 @@ def run_in_sandbox(cmd: list[str], env: dict[str, str]=None) -> int:
         '--bind',
         proton,
         proton,
+        '--bind',
+        game,
+        game
     ]
 
     return subprocess.run(

--- a/util.py
+++ b/util.py
@@ -848,8 +848,9 @@ def set_cpu_topology_limit(core_limit: int, ignore_user_setting: bool = False) -
 def run_in_sandbox(cmd: list[str], env: dict[str, str]=None) -> int:
     """Run a command within a sandbox.
     The command will run in an temporary environment that is isolated from the
-    host where only the path to the Proton, WINE prefix and game directory are
-    read-write and visible to the running command
+    host where only the path to the Proton, WINE prefix, game directory and
+    winetricks cache directory are read-write and visible to the running
+    command
 
     When the parent process of the command dies, all of its children will die
     with it. A dictionary that contains the user's environment variables is

--- a/util.py
+++ b/util.py
@@ -12,6 +12,7 @@ import zipfile
 import subprocess
 import urllib.request
 import functools
+from pathlib import Path
 from socket import socket, AF_INET, SOCK_DGRAM
 from typing import Union, Literal, Mapping
 
@@ -287,6 +288,11 @@ def protontricks(verb: str) -> bool:
                 if 'waitforexitandrun' not in arg:
                     sys.argv[idx] = arg.replace('run', 'waitforexitandrun')
                     log.debug(str(sys.argv))
+
+            # Make sure the cache exists
+            winetricks_cache = os.path.expanduser("~/.cache/winetricks") 
+            if not os.path.exists(winetricks_cache):
+                os.makedirs(winetricks_cache, exist_ok=True)
 
             # Run winetricks
             log.info('Using winetricks verb ' + verb)
@@ -852,6 +858,7 @@ def run_in_sandbox(cmd: list[str], env: dict[str, str]=None) -> int:
     pfx = protonprefix()
     proton = protondir()
     game = get_game_install_path()
+    winetricks_cache = Path.home().joinpath(".cache", "winetricks").as_posix()
 
     if not proton or not pfx:
         log.warn("WINEPREFIX or PROTONPATH is not set or empty")
@@ -910,6 +917,9 @@ def run_in_sandbox(cmd: list[str], env: dict[str, str]=None) -> int:
         '--bind',
         game,
         game
+        '--bind-try',
+        winetricks_cache,
+        winetricks_cache
     ]
 
     return subprocess.run(


### PR DESCRIPTION
Currently, winetricks and its descendent processes are not under a subreaper, so when the user force quits the program execution (e.g., keyboard interrupt via ctrl+c, closing a launcher window) they will not be reaped. As a result, the user has to manually kill the winetricks background processes.

This pull request makes it so winetricks and its descendents processes will be sandboxed and killed automatically when the user forcibly quits by running the command via bubblewrap provided by the Steam runtime platform. Additionally, _only_ the entire file hierarchy except Wine prefix, Proton, winetricks cache and game directory will be mounted read-only and _only_ the host's network namespace will be shared to provide some security.
