### PR TITLE
Add fixes for COJ Gunslinger on Steam

### DIFF
--- a/gamefixes-steam/204450.py
+++ b/gamefixes-steam/204450.py
@@ -1,0 +1,13 @@
+""" Game fix Call of Juarez: Gunslinger
+"""
+#pylint: disable=C0103
+
+from protonfixes import util
+
+def main():
+    """ installs wmp11
+    """
+    # Fixes missing audio cutscenes
+    util.protontricks('wmp11')
+    # Seems to choke on more than 32 cores, needs testing
+    util.set_cpu_topology_limit(31)

--- a/gamefixes-steam/204450.py
+++ b/gamefixes-steam/204450.py
@@ -1,4 +1,4 @@
-""" Game fix Call of Juarez: Gunslinger
+""" Game fixes Call of Juarez: Gunslinger
 """
 #pylint: disable=C0103
 
@@ -7,7 +7,7 @@ from protonfixes import util
 def main():
     """ installs wmp11
     """
-    # Fixes missing audio cutscenes
+    # Fixes missing cutscenes
     util.protontricks('wmp11')
     # Seems to choke on more than 32 cores, needs testing
     util.set_cpu_topology_limit(31)


### PR DESCRIPTION
- Add wmp11 to fix cutscenes
- Limit to 31 cores

Please let me know if I missed something. Thanks!

wmp11 and 31 cores fixes are due to user reports:

https://github.com/ValveSoftware/Proton/issues/366

https://www.protondb.com/app/204450

It seems like both `wmp9` and `wmp11` work, so we should prefer the newer version.
I am using `wmp11` and it works normally.