### PR TITLE
Adding protonfix for Hogwarts Legacy

### DIFF
--- a/gamefixes-egs/umu-990080.py
+++ b/gamefixes-egs/umu-990080.py
@@ -1,0 +1,1 @@
+../gamefixes-steam/990080.py

--- a/gamefixes-egs/umu-990080.py
+++ b/gamefixes-egs/umu-990080.py
@@ -1,1 +1,9 @@
-../gamefixes-steam/990080.py
+""" Game fix Hogwarts Legacy
+"""
+#pylint: disable=C0103
+
+from protonfixes import util
+
+def main():
+    # Requires vcrun2019 to launch
+    util.protontricks('vcrun2019')

--- a/gamefixes-steam/990080.py
+++ b/gamefixes-steam/990080.py
@@ -1,9 +1,0 @@
-""" Game fix Hogwarts Legacy
-"""
-#pylint: disable=C0103
-
-from protonfixes import util
-
-def main():
-    # Requires vcrun2019 to launch
-    util.protontricks('vcrun2019')

--- a/gamefixes-steam/990080.py
+++ b/gamefixes-steam/990080.py
@@ -1,0 +1,9 @@
+""" Game fix Hogwarts Legacy
+"""
+#pylint: disable=C0103
+
+from protonfixes import util
+
+def main():
+    # Requires vcrun2019 to launch
+    util.protontricks('vcrun2019')


### PR DESCRIPTION
vcrun2019 is required for the game to start. Otherwise the game will throw an error on start.