### PR TITLE
gog: add fix for original resident evil

### DIFF
--- a/gamefixes-gog/umu-1580232252.py
+++ b/gamefixes-gog/umu-1580232252.py
@@ -6,3 +6,4 @@ from protonfixes import util
 
 def main():
     util.winedll_override('ddraw', 'n,b')
+    util.winedll_override('dinput', 'n,b')

--- a/gamefixes-gog/umu-1580232252.py
+++ b/gamefixes-gog/umu-1580232252.py
@@ -1,0 +1,8 @@
+""" Resident Evil (1997)
+"""
+#pylint: disable=C0103
+
+from protonfixes import util
+
+def main():
+    util.winedll_override('ddraw', 'n,b')


### PR DESCRIPTION
cutscenes still don't work, but that may be a wine issue