### PR TITLE
Add workaround for Elden Ring multiplayer for players that don't own the DLC

### DIFF
--- a/gamefixes-steam/1245620.py
+++ b/gamefixes-steam/1245620.py
@@ -1,0 +1,10 @@
+"""Game fix for Elden Ring: Manually create the DLC.bdt file to work around the "Inappropriate activity detected" error for players that don't own the DLC"""
+
+import pathlib
+from util import get_game_install_path
+
+def main():
+	if not pathlib.Path(f"{get_game_install_path()}/DLC.bdt").exists():
+		# Create the DLC.bdt file if it doesn't already exist, which is known to fix Easy AntiCheat not working for players that don't own the DLC
+		# A blank file is enough to get multiplayer working
+		open(f"{get_game_install_path()}/DLC.bdt", 'w').close()

--- a/gamefixes-steam/1245620.py
+++ b/gamefixes-steam/1245620.py
@@ -1,10 +1,10 @@
-"""Game fix for Elden Ring: Manually create the DLC.bdt file to work around the "Inappropriate activity detected" error for players that don't own the DLC"""
+"""Game fix for Elden Ring: Manually create the `DLC.bdt` file to work around the "Inappropriate activity detected" error for players that don't own the DLC"""
 
-import pathlib
+from pathlib import Path
 from protonfixes import util
 
 def main():
-	if not pathlib.Path(f"{util.get_game_install_path()}/Game/DLC.bdt").exists():
+	if not Path(f"{util.get_game_install_path()}/Game/DLC.bdt").exists():
 		# Create the DLC.bdt file if it doesn't already exist, which is known to fix Easy AntiCheat not working for players that don't own the DLC
 		# A blank file is enough to get multiplayer working
-		open(f"{util.get_game_install_path()}/Game/DLC.bdt", 'w').close()
+		open(f"{util.get_game_install_path()}/Game/DLC.bdt", 'wb').close()

--- a/gamefixes-steam/1245620.py
+++ b/gamefixes-steam/1245620.py
@@ -4,7 +4,7 @@ import pathlib
 from util import get_game_install_path
 
 def main():
-	if not pathlib.Path(f"{get_game_install_path()}/DLC.bdt").exists():
+	if not pathlib.Path(f"{get_game_install_path()}/Game/DLC.bdt").exists():
 		# Create the DLC.bdt file if it doesn't already exist, which is known to fix Easy AntiCheat not working for players that don't own the DLC
 		# A blank file is enough to get multiplayer working
-		open(f"{get_game_install_path()}/DLC.bdt", 'w').close()
+		open(f"{get_game_install_path()}/Game/DLC.bdt", 'w').close()

--- a/gamefixes-steam/1245620.py
+++ b/gamefixes-steam/1245620.py
@@ -1,10 +1,10 @@
 """Game fix for Elden Ring: Manually create the DLC.bdt file to work around the "Inappropriate activity detected" error for players that don't own the DLC"""
 
 import pathlib
-from util import get_game_install_path
+from protonfixes import util
 
 def main():
-	if not pathlib.Path(f"{get_game_install_path()}/Game/DLC.bdt").exists():
+	if not pathlib.Path(f"{util.get_game_install_path()}/Game/DLC.bdt").exists():
 		# Create the DLC.bdt file if it doesn't already exist, which is known to fix Easy AntiCheat not working for players that don't own the DLC
 		# A blank file is enough to get multiplayer working
-		open(f"{get_game_install_path()}/Game/DLC.bdt", 'w').close()
+		open(f"{util.get_game_install_path()}/Game/DLC.bdt", 'w').close()


### PR DESCRIPTION
Looking around online and at ProtonDB, the game's Easy Anticheat expects the `Game/DLC.bdt` file to be present for Linux players in order to work correctly, regardless of whether they actually own the DLC that file comes from, and as a result players that don't have the DLC are getting an "Inappropriate activity detected" error when trying to play online.

This workaround simply creates a blank `DLC.bdt` file under `Elden Ring/Game`, which is known to fix the multiplayer for those that don't own the Shadow of the Erdtree DLC.

More information: https://github.com/ValveSoftware/Proton/issues/5613#issuecomment-2181650512, https://github.com/ValveSoftware/Proton/issues/5613#issuecomment-2185352393