### PR TITLE
xliveless.verb: Fix install location of xlive.dll

### DIFF
--- a/verbs/xliveless.verb
+++ b/verbs/xliveless.verb
@@ -1,15 +1,15 @@
 w_metadata xliveless dlls \
     title="Games for Windows Live (gfw / gfwl) - xlive.dll mock, single player only" \
     publisher="ThirteenAG" \
-    year="2022" \
+    year="2024" \
     media="download" \
     file1="Ultimate-ASI-Loader.zip" \
-    installed_file1="xlive.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/xlive.dll"
 
 load_xliveless()
 {
-    w_download https://github.com/ThirteenAG/Ultimate-ASI-Loader/releases/download/v4.68/Ultimate-ASI-Loader.zip 7517c7d5bd8c475f18e6545b7998df379eed6e2e0a19fcd2139669152f9bcddb ${file1}
+    w_download https://github.com/ThirteenAG/Ultimate-ASI-Loader/releases/download/v7.7.0/Ultimate-ASI-Loader.zip 62778dc40a2f44b1636db3aca5a3d01727a1c7eb40b1c49d42b71472631cd2d7
     w_try_unzip "${W_TMP}" "${W_CACHE}/${W_PACKAGE}/${file1}" "dinput8.dll"
-    w_try_cp_dll "${W_TMP}/dinput8.dll" "xlive.dll"
+    w_try_cp_dll "${W_TMP}/dinput8.dll" "${W_SYSTEM32_DLLS}/xlive.dll"
     w_override_dlls native xlive
 }


### PR DESCRIPTION
Previously this wouldn't install xlive.dll in any system folders, essentially making this fix do nothing.

I bumped the year, as well as the version of the ASI Loader as there's been quite a few releases since version 4.68.

Tested this with DiRT2 (A GFWL title) But I could also test on Fable 3 if that is something that would be needed. :)