### PR TITLE
steam: Add Dirt 2 protonfix

### DIFF
--- a/gamefixes-steam/12840.py
+++ b/gamefixes-steam/12840.py
@@ -1,0 +1,11 @@
+""" Game fix for Dirt 2
+"""
+
+from protonfixes import util
+
+
+def main():
+    """ This game uses GFWL, which causes it to fail to launch. xliveless is needed to get this working.
+    """
+
+    util.protontricks('xliveless')


### PR DESCRIPTION
This game uses GFWL, so it fails to launch without xliveless being used.

Ideally for this fix to work #107 should be merged.