### PR TITLE
fix: run wmp9 verb instead of wmp9_x86_64

### DIFF
--- a/gamefixes-steam/1097880.py
+++ b/gamefixes-steam/1097880.py
@@ -10,4 +10,4 @@ def main():
 
     # The whole game is only videos and require wmp9 & quartz
     util.protontricks('quartz')
-    util.protontricks('wmp9_x86_64')
+    util.protontricks("wmp9")

--- a/gamefixes-steam/211420.py
+++ b/gamefixes-steam/211420.py
@@ -8,9 +8,9 @@ def main():
     """ Needs WMP9, devenum, quartz, dinput and win7 """
 
     #For main menu, intro and outro playback
-    util.protontricks('wmp9_x86_64')
     util.protontricks('devenum')
     util.protontricks('quartz')
+    util.protontricks("wmp9")
 
     #In case if someone wishes to use DSfix
     util.protontricks('dinput8')

--- a/gamefixes-steam/388750.py
+++ b/gamefixes-steam/388750.py
@@ -10,4 +10,4 @@ def main():
 
     # https://github.com/ValveSoftware/Proton/issues/703#issuecomment-416075961
     util.protontricks('devenum')
-    util.protontricks('wmp9_x86_64')
+    util.protontricks("wmp9")


### PR DESCRIPTION
Related to https://github.com/Open-Wine-Components/umu-protonfixes/issues/111

Fixes running a non-existent winetricks verb for _Dark Souls Prepare To Die Edition_, _Chronophantasma Extend_, and _Super Naughty Maid 2_.

**Note**: wmp9 may be unnecessary due to latest upstream winegstreamer changes.
