### PR TITLE
Add fix for Full Metal Daemon Muramasa

### DIFF
--- a/gamefixes-gog/umu-1209310984.py
+++ b/gamefixes-gog/umu-1209310984.py
@@ -1,0 +1,12 @@
+"""Game fix for Full Metal Daemon Muramasa
+
+This game is borked on gog due to audio synchronization (xaudio) issues. To
+make this game playable, xaudio2_9.dll simply needs to be in the game
+directory and renamed to xaudio2_8.dll.
+"""
+
+from protonfixes import util
+
+
+def main():
+    pass

--- a/gamefixes-gog/umu-1209310984.py
+++ b/gamefixes-gog/umu-1209310984.py
@@ -5,8 +5,54 @@ make this game playable, xaudio2_9.dll simply needs to be in the game
 directory and renamed to xaudio2_8.dll.
 """
 
+import os
+from gzip import open as gzip_open
+from hashlib import sha256
+from tempfile import mkdtemp
+from urllib.request import urlopen
+
 from protonfixes import util
+from protonfixes.logger import log
 
 
 def main():
-    pass
+    arc = "https://github.com/user-attachments/files/16788423/xaudio2_8.dll.gz"
+    hashsum_file = "173cac0a7931989d66338e0d7779e451f2f01b2377903df7954d86c07c1bc8fb"
+    tmp = f"{mkdtemp()}/xaudio2_8.dll.gz"
+    hashsum = sha256()
+    path_dll = f"{util.get_game_install_path()}/xaudio2_8.dll"
+
+    # Full Metal Daemon from gog will not have the xaudio2_8.dll
+    if os.path.exists(path_dll):
+        log.info(
+            f"xaudio2_8.dll exists in '{util.get_game_install_path()}', skipping..."
+        )
+        return
+
+    # Download the archive
+    with urlopen(arc, timeout=30) as resp:
+        if resp.status != 200:
+            log.warn(f"github returned the status code: {resp.status}")
+            return
+
+        with open(tmp, mode="wb", buffering=0) as file:
+            chunk_size = 64 * 1024  # 64 KB
+            buffer = bytearray(chunk_size)
+            view = memoryview(buffer)
+
+            while size := resp.readinto(buffer):
+                file.write(view[:size])
+                hashsum.update(view[:size])
+
+    # Verify the compessed file
+    if hashsum_file != hashsum.hexdigest():
+        log.warn(f"Digest mismatch: {arc}")
+        log.warn(f"Expected '{hashsum_file}', skipping...")
+        return
+
+    # Write xaudio2_8.dll to the game directory
+    # NOTE: The file is actually xaudio2_9.dll from winetricks but renamed
+    log.info("Applying fix for 'Full Metal Daemon Muramasa'...")
+    with gzip_open(tmp, "rb") as reader:
+        with open(path_dll, "wb") as writer:
+            writer.write(reader.read())


### PR DESCRIPTION
Full Metal Daemon Muramasa is borked on gog when running the game through Proton. After reaching the main menu and clicking Start, the game is observed to, at some point, freeze due to audio-related deadlocks from wine resulting in errors such as:
```
err:ntdll:RtlpWaitForCriticalSection section 0x76b5d38 "?" wait timed out in thread 0138, blocked by 0148, retrying (60 sec)
```

This title uses the same game engine as other Nitroplus titles such as _YOU and ME and HER: A Love Story_ (1293820), which exhibits the exact symptoms. However, unlike those, falling back to wine server sync and running the `xact` verb is not sufficient. To fix the deadlocks, `xaudio2_8.dll` needs to be within the game directory.

Tested against GE-Proton9-11