### PR TITLE
fix: build xorg-macros before xrandr

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "subprojects/libmspack"]
 	path = subprojects/libmspack
 	url = https://github.com/kyz/libmspack.git
+[submodule "subprojects/xutils-dev"]
+	path = subprojects/xutils-dev
+	url = https://salsa.debian.org/xorg-team/app/xutils-dev.git

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,10 @@ protonfixes-install: protonfixes
 #
 
 $(OBJDIR)/.build-xrandr-dist: | $(OBJDIR)
+	$(info :: Installing xorg-macros )
+	cd subprojects/xutils-dev/util-macros && \
+	./configure --prefix=/usr && \
+	make install
 	$(info :: Building xrandr )
 	cd subprojects/x11-xserver-utils/xrandr && \
 	./configure --prefix=/usr && \


### PR DESCRIPTION
[Fixes potential build errors](https://github.com/Open-Wine-Components/umu-protonfixes/actions/runs/10647130491/job/29514733571) for the `xrandr` target by first installing `xorg-macros`. Attempting to build xrandr without this build dependency may result in the following error:

```
Package xorg-macros was not found in the pkg-config search path.
Perhaps you should add the directory containing `xorg-macros.pc'
to the PKG_CONFIG_PATH environment variable
No package 'xorg-macros' found
checking whether make supports nested variables... (cached) yes
checking for floor in -lm... yes
checking for XRANDR... yes
checking that generated files are newer than configure... done
configure: creating ./config.status
config.status: creating Makefile
config.status: creating man/Makefile
config.status: creating config.h
config.status: executing depfiles commands
make[1]: Entering directory '/workspace/subprojects/x11-xserver-utils/xrandr'
CDPATH="${ZSH_VERSION+.}:" && cd . && /bin/bash '/workspace/subprojects/x11-xserver-utils/xrandr/missing' aclocal-1.16 
configure.ac:34: error: must install xorg-macros 1.8 or later before running autoconf/autogen
configure.ac:34: the top level
autom4te: /usr/bin/m4 failed with exit status: 1
aclocal-1.16: error: autom4te failed with exit status: 1
make[1]: Leaving directory '/workspace/subprojects/x11-xserver-utils/xrandr'
make[1]: *** [Makefile:445: aclocal.m4] Error 1
make: *** [Makefile:36: builddir/.build-xrandr-dist] Error 2
```

which may negatively [impact the build process for GE-Proton](https://github.com/GloriousEggroll/proton-ge-custom/pull/119).