### PR TITLE
Delete fix for APB Reloaded

### DIFF
--- a/gamefixes-steam/113400.py
+++ b/gamefixes-steam/113400.py
@@ -1,9 +1,0 @@
-""" APB Reloaded: Fix Wrong DLL error and Steam login crash
-"""
-#pylint: disable=C0103
-
-from protonfixes import util
-
-def main():
-    # Install Visual C++ Runtime 2017
-    util.protontricks('vcrun2017')


### PR DESCRIPTION
The fix for the crash is now included in Proton Experimental Bleeding Edge and GE-Proton9-12.
Haven't been able to find any other issues. Feel free to verify ofc.