### PR TITLE
star citizen gamefixes

### DIFF
--- a/gamefixes-umu/umu-starcitizen.py
+++ b/gamefixes-umu/umu-starcitizen.py
@@ -8,11 +8,5 @@ def main() -> None:
     # eac workaround
     util.set_environment('EOS_USE_ANTICHEATCLIENTNULL', '1')
 
-    # needed for nvidia vulkan
-    util.set_environment('WINE_HIDE_NVIDIA_GPU', '1')
-
-    # needed for amd vulkan
-    util.set_environment('dual_color_blend_by_location', 'true')
-
-    # allow the RSI Launcher to auto-update itself
+    # RSI Launcher depends on powershell
     util.protontricks('powershell')


### PR DESCRIPTION
- AMD environment variable is no longer needed

- Nvidia variable enables Vulkan but prevents DLSS. Alternate method of patching libcuda has become favorable as it enables both Vulkan and DLSS

https://github.com/jp7677/dxvk-nvapi/issues/174#issuecomment-2227462795

https://github.com/starcitizen-lug/knowledge-base/wiki/Troubleshooting#dlssdeep-learning-super-sampling--vulkan