### PR TITLE
Environment override to allow God of War: Ragnarok to run on desktop Linux

### DIFF
--- a/gamefixes-steam/2322010.py
+++ b/gamefixes-steam/2322010.py
@@ -1,0 +1,6 @@
+"Game fix for God of War: Ragnarok"
+from os import environ
+
+def main():
+	# Game won't launch on non-Steam Deck systems without this environment variable
+	environ['SteamDeck'] = '1'


### PR DESCRIPTION
Game won't start on non-Steam Deck systems without `SteamDeck=1` environment variable, and is otherwise considered to be fully playable with that variable set.

Source: https://github.com/ValveSoftware/Proton/issues/8107#issuecomment-2361421991