### PR TITLE
fix: gta v trying to init steamapi for non-steam entries

### DIFF
--- a/gamefixes-steam/271590.py
+++ b/gamefixes-steam/271590.py
@@ -1,9 +1,13 @@
 """Game fix for GTAV"""
 
+import os
 from protonfixes import util
 
 
 def main() -> None:
     """Game fix for GTAV"""
-    # Set SteamGameId so that non-steam versions can pick up steam-specific fixes in proton's wine code
-    util.set_environment('SteamGameId', '271590')
+    # Rockstar reads SteamAppId and tries to init Steam API
+    # We want to avoid this when running from Epic for example
+    game_id = os.environ.get("UMU_ID")
+    if game_id and not game_id.isnumeric():
+        util.del_environment("SteamAppId")


### PR DESCRIPTION
Since Rockstar Launcher uses `SteamAppId` to detect if it should call SteamAPI, we should prevent this from happening for non-steam builds.
At the moment the only workarounds applied by Proton and Wine are
- `WINE_DISABLE_VULKAN_OPWR=1`
- workaround for rockstar installer based on `STEAM_COMPAT_APP_ID` (protonfixes are not called)

These should be called even if we don't set those vars in protonfix