### PR TITLE
Add patch for libcuda.so and implement fix for Star Citizen

### DIFF
--- a/gamefixes-umu/umu-starcitizen.py
+++ b/gamefixes-umu/umu-starcitizen.py
@@ -8,11 +8,9 @@ def main() -> None:
     # eac workaround
     util.set_environment('EOS_USE_ANTICHEATCLIENTNULL', '1')
 
-    # needed for nvidia vulkan
-    util.set_environment('WINE_HIDE_NVIDIA_GPU', '1')
+    # patch libcuda to workaround crashes related to DLSS
+    # See: https://github.com/jp7677/dxvk-nvapi/issues/174#issuecomment-2227462795
+    util.patch_libcuda()
 
-    # needed for amd vulkan
-    util.set_environment('dual_color_blend_by_location', 'true')
-
-    # allow the RSI Launcher to auto-update itself
+    # RSI Launcher depends on powershell
     util.protontricks('powershell')

--- a/util.py
+++ b/util.py
@@ -454,7 +454,7 @@ def patch_libcuda() -> bool:
         try:
             with open(libcuda_path, 'rb') as f:
                 binary_data = f.read()
-        except IOError as e:
+        except OSError as e:
             log.error(f'Unable to read libcuda.so: {e}')
             return False
 
@@ -465,12 +465,12 @@ def patch_libcuda() -> bool:
         try:
             with open(patched_library, 'wb') as f:
                 f.write(patched_binary_data)
-        except IOError as e:
+        except OSError as e:
             log.error(f'Unable to write patched libcuda.so to {patched_library}: {e}')
             return False
 
         log.info(f'Patched libcuda.so saved to: {patched_library}')
-        
+
         log.info(f'Setting LD_PRELOAD to: {patched_library}')
         set_environment('LD_PRELOAD', patched_library)
         return True

--- a/util.py
+++ b/util.py
@@ -438,12 +438,11 @@ def patch_libcuda() -> bool:
             log.warn('ldconfig not found in PATH.')
             return False
 
-        # Use subprocess.run with explicit encoding handling
+        # Use subprocess.run with capture_output and explicit encoding handling
         try:
             result = subprocess.run(
                 [ldconfig_path, '-p'],
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
+                capture_output=True,
                 check=True
             )
             # Decode the output using utf-8 with fallback to locale preferred encoding

--- a/util.py
+++ b/util.py
@@ -7,7 +7,6 @@ import sys
 import re
 import shutil
 import signal
-import stat
 import tarfile
 import zipfile
 import subprocess
@@ -485,9 +484,7 @@ def patch_libcuda() -> bool:
                 f.write(patched_binary_data)
 
             # Set permissions to rwxr-xr-x (755)
-            os.chmod(patched_library, stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR |  # Owner: rwx
-                     stat.S_IRGRP | stat.S_IXGRP |                   # Group: r-x
-                     stat.S_IROTH | stat.S_IXOTH)                    # Others: r-x
+            os.chmod(patched_library, 0o755)
             log.debug(f'Permissions set to rwxr-xr-x for {patched_library}')
         except OSError as e:
             log.crit(f'Unable to write patched libcuda.so to {patched_library}: {e}')

--- a/util.py
+++ b/util.py
@@ -8,6 +8,7 @@ import sys
 import re
 import shutil
 import signal
+import stat
 import tarfile
 import zipfile
 import subprocess
@@ -465,6 +466,12 @@ def patch_libcuda() -> bool:
         try:
             with open(patched_library, 'wb') as f:
                 f.write(patched_binary_data)
+
+            # Set permissions to rwxr-xr-x (755)
+            os.chmod(patched_library, stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR |  # Owner: rwx
+                            stat.S_IRGRP | stat.S_IXGRP |                   # Group: r-x
+                            stat.S_IROTH | stat.S_IXOTH)                    # Others: r-x
+            log.info(f'Permissions set to rwxr-xr-x for {patched_library}')
         except OSError as e:
             log.error(f'Unable to write patched libcuda.so to {patched_library}: {e}')
             return False


### PR DESCRIPTION
This PR adds a function (patch_libcuda) into util.py which patches libcuda.so with the approach seen here: https://github.com/jp7677/dxvk-nvapi/issues/174#issuecomment-2227462795

This may also be useful for other games that over-allocate memory when enabling DLSS (I know this affects Star Citizen but I don't have NVIDIA so I am not aware of other titles that have this issue.)

Additionally this expands https://github.com/Open-Wine-Components/umu-protonfixes/pull/132 by integrating that into the protonfix.

Please let me know if you'd like any changes. Testers are also welcome, I don't have an NVIDIA GPU to test this fix.. but in theory it should work based on my eyeballing of the code.

This could also be moved into `umu-starcitizen.py` but there may be other affected games this could help with.