### PR TITLE
add fix for Worms: Blast(70650)

### DIFF
--- a/gamefixes-steam/70650.py
+++ b/gamefixes-steam/70650.py
@@ -4,6 +4,6 @@ from protonfixes import util
 
 
 def main() -> None:
-    """ Installs directmusic to fix menu and game music """
+    """Installs directmusic to fix menu and game music"""
 
     util.protontricks('directmusic')

--- a/gamefixes-steam/70650.py
+++ b/gamefixes-steam/70650.py
@@ -5,5 +5,4 @@ from protonfixes import util
 
 def main() -> None:
     """Installs directmusic to fix menu and game music"""
-
     util.protontricks('directmusic')

--- a/gamefixes-steam/70650.py
+++ b/gamefixes-steam/70650.py
@@ -1,0 +1,9 @@
+""" Game fix for Worms: Blast """
+
+from protonfixes import util
+
+
+def main() -> None:
+    """ Installs directmusic to fix menu and game music """
+
+    util.protontricks('directmusic')

--- a/gamefixes-steam/70650.py
+++ b/gamefixes-steam/70650.py
@@ -1,4 +1,4 @@
-""" Game fix for Worms: Blast """
+"""Game fix for Worms: Blast"""
 
 from protonfixes import util
 


### PR DESCRIPTION
Fixes in-menu and in-game music by installing directmusic. Tested with GE-Proton9-13 from a cleanly generated game prefix. 

I'm also getting some slight music audio pop if i don't use the env variable PULSE_LATENCY_MSEC=120 but i'm not sure if it's not just my hardware.  

Steam page: https://store.steampowered.com/app/70650/Worms_Blast/