### PR TITLE
Game fix for Plain Sight

### DIFF
--- a/gamefixes-steam/49900.py
+++ b/gamefixes-steam/49900.py
@@ -1,0 +1,7 @@
+"""Game fix for Plain Sight"""
+
+from protonfixes import util
+
+def main() -> None:
+    """Installs XNA 3.1 to avoid crash when loading levels"""
+    util.protontricks('xna31')


### PR DESCRIPTION
Plain Sight needs XNA 3.1 or it will get stuck when entering any level. 

I've noticed executing the verb xna31 works with `winetricks-next` but can fail with currently stable version 20240105.  I guess if it should fail some time in the future it would just fail silently in the background and game would launch regardless with Proton just without the fix.    

https://github.com/ValveSoftware/Proton/issues/7594