### PR TITLE
fix: Remove d3dx11_42 fix for Total War Rome 2

### DIFF
--- a/gamefixes-steam/214950.py
+++ b/gamefixes-steam/214950.py
@@ -4,10 +4,9 @@ from protonfixes import util
 
 
 def main() -> None:
-    """Installs d3dx11_42, d3dcompiler_42, directplay
+    """Installs d3dcompiler_42, directplay
     Disable esync and fsync
     """
-    util.protontricks('d3dx11_42')
     util.protontricks('d3dcompiler_42')
     util.protontricks('directplay')
     util.disable_esync()


### PR DESCRIPTION
Builtin should work fine in Proton Wine since commit https://github.com/ValveSoftware/wine/commit/5d34c6c0dd1618b4da8eec017da3f8231d753bd9. Haven't found any other issues.

Feel free to verify ofc.