### PR TITLE
fix: Remove d3dx11_42 fix for Total War Shogun 2

### DIFF
--- a/gamefixes-steam/34330.py
+++ b/gamefixes-steam/34330.py
@@ -4,5 +4,4 @@ from protonfixes import util
 
 
 def main() -> None:
-    util.protontricks('d3dx11_42')
     util.protontricks('d3dcompiler_43')


### PR DESCRIPTION
Issues should now be addressed with the builtin version in Proton Experimental Wine. Haven't found anymore when testing.
As always feel free to verify.

https://github.com/ValveSoftware/Proton/issues/7110