### PR TITLE
star citizen gamefixes

### DIFF
--- a/gamefixes-umu/umu-starcitizen.py
+++ b/gamefixes-umu/umu-starcitizen.py
@@ -4,13 +4,12 @@ from protonfixes import util
 
 
 def main() -> None:
-    """EAC Workaround"""
-    # eac workaround
-    util.set_environment('EOS_USE_ANTICHEATCLIENTNULL', '1')
-
     # patch libcuda to workaround crashes related to DLSS
     # See: https://github.com/jp7677/dxvk-nvapi/issues/174#issuecomment-2227462795
     util.patch_libcuda()
 
     # RSI Launcher depends on powershell
     util.protontricks('powershell')
+
+    # RSI Launcher animation
+    util.winedll_override("libglesv2", "builtin")


### PR DESCRIPTION
- Remove EAC workaround
  -  Enforcement is being enabled in Star Citizen 3.24.2
  -  A solution for EAC has been identified, requiring user action in the RSI Launcher to change game files to a location on `Z:\` instead of `C:\`
- ~~Add `arial` and `tahoma` fonts that are missing for some users~~
- `libglesv2` set to `builtin` improves RSI Launcher animation responsiveness