### PR TITLE
Remove EAC workaround

### DIFF
--- a/gamefixes-umu/umu-starcitizen.py
+++ b/gamefixes-umu/umu-starcitizen.py
@@ -4,9 +4,7 @@ from protonfixes import util
 
 
 def main() -> None:
-    """EAC Workaround"""
-    # eac workaround
-    util.set_environment('EOS_USE_ANTICHEATCLIENTNULL', '1')
+    """Patches libcuda & installs required dependencies"""
 
     # patch libcuda to workaround crashes related to DLSS
     # See: https://github.com/jp7677/dxvk-nvapi/issues/174#issuecomment-2227462795


### PR DESCRIPTION
EAC has been enabled on the servers. It is not possible to play ignoring the AC anymore and so this workaround has become incompatible with current server versions.

* https://github.com/starcitizen-lug/knowledge-base/wiki/Tips-and-Tricks#easy-anti-cheat