### PR TITLE
Create 2552430.py (Kingdom Hearts HD ReMIX)

### DIFF
--- a/gamefixes-steam/2552430.py
+++ b/gamefixes-steam/2552430.py
@@ -1,0 +1,8 @@
+"""Game fix for KINGDOM HEARTS -HD 1.5+2.5 ReMIX-"""
+
+from protonfixes import util
+
+
+def main() -> None:
+    """Game needs SteamDeck=1 for cutscenes to work."""
+    util.set_environment('SteamDeck', '1')


### PR DESCRIPTION
Set environment `SteamDeck=1`, to allow for cutscenes to play (rather than a black screen) in Kingdom Hearts 1.5+2.5 HD ReMIX