### PR TITLE
Fix for METAL GEAR SOLID 2 SUBSTANCE on GOG

### DIFF
--- a/gamefixes-gog/umu-metalgearsolid2substance.py
+++ b/gamefixes-gog/umu-metalgearsolid2substance.py
@@ -1,0 +1,11 @@
+"""METAL GEAR SOLID 2 SUBSTANCE"""
+# GOG-ID 2069117974	
+
+from protonfixes import util
+
+
+def main() -> None:
+    util.protontricks('dsound')
+    util.protontricks('directmusic')
+    util.protontricks('dsdmo')
+    util.protontricks('quartz')


### PR DESCRIPTION
Protonfix for METAL GEAR SOLID 2 SUBSTANCE.

Directly installed from GOG does not work for me. I found this fix from WineHQ and it works now:
[https://appdb.winehq.org/objectManager.php?sClass=version&iId=7455&sAllBugs](url)

Also, I'm investigating if anyone else had this happen and I found this similar fix in Lutris:
[https://lutris.net/games/install/35023/view](url)