### PR TITLE
Disable Esync and Fsync for Disgaea 4 Complete + to stop game from crashing on launch

### DIFF
--- a/gamefixes-steam/1233880.py
+++ b/gamefixes-steam/1233880.py
@@ -1,0 +1,8 @@
+"Game fix for Disgaea 4 Complete+"
+
+from protonfixes import util
+
+def main():
+	"Usually won't reach menu unless Esync and Fsync are disabled."
+	util.disable_esync()
+	util.disable_fsync()

--- a/gamefixes-steam/1233880.py
+++ b/gamefixes-steam/1233880.py
@@ -1,4 +1,4 @@
-"Game fix for Disgaea 4 Complete+"
+"""Game fix for Disgaea 4 Complete+"""
 
 from protonfixes import util
 

--- a/gamefixes-steam/1233880.py
+++ b/gamefixes-steam/1233880.py
@@ -3,6 +3,6 @@
 from protonfixes import util
 
 def main() -> None:
-	"Usually won't reach menu unless Esync and Fsync are disabled."
+	"""Usually won't reach menu unless Esync and Fsync are disabled""
 	util.disable_esync()
 	util.disable_fsync()

--- a/gamefixes-steam/1233880.py
+++ b/gamefixes-steam/1233880.py
@@ -3,6 +3,6 @@
 from protonfixes import util
 
 def main() -> None:
-	"""Usually won't reach menu unless Esync and Fsync are disabled""
+	"""Usually won't reach menu unless Esync and Fsync are disabled"""
 	util.disable_esync()
 	util.disable_fsync()

--- a/gamefixes-steam/1233880.py
+++ b/gamefixes-steam/1233880.py
@@ -2,7 +2,7 @@
 
 from protonfixes import util
 
-def main():
+def main() -> None:
 	"Usually won't reach menu unless Esync and Fsync are disabled."
 	util.disable_esync()
 	util.disable_fsync()


### PR DESCRIPTION
There is a regression in Proton 8 that is causing the game to crash at launch unless Esync and Fsync are explicitly disabled, and those variables are not set by default in official Proton.

See also: https://github.com/ValveSoftware/Proton/issues/5164#issuecomment-2308415801