### PR TITLE
Fix Bethesda mod support

### DIFF
--- a/gamefixes-steam/22330.py
+++ b/gamefixes-steam/22330.py
@@ -22,7 +22,7 @@ def main_with_id(game_id: str) -> None:
 
     # Run script extender if it exists.
     mapping = get_redirect_name(game_id)
-    if os.path.isfile(mapping.from_name):
+    if os.path.isfile(mapping.to_name):
         util.replace_command(mapping.from_name, mapping.to_name)
 
 


### PR DESCRIPTION
The mod support is currently checking if the original executable exists instead of the mod loader executable.  This causes installations without mod loaders to stop working.

Checking if the mod loader executable exists fixes this issue for installations without the mod loader.