### PR TITLE
Audio fix for Mini Ninjas

### DIFF
--- a/gamefixes-steam/35000.py
+++ b/gamefixes-steam/35000.py
@@ -1,0 +1,7 @@
+"""Game fix for Mini Ninjas"""
+
+from protonfixes import util
+
+def main() -> None:
+	"""Game needs OpenAL library for audio to work, but the game doesn't include it by default, leading to missing audio in-game, even on Windows."""
+	util.protontricks('openal')


### PR DESCRIPTION
The game needs an external library for audio to work, which it doesn't include by default, leading to missing audio in-game, which apparently also affects Windows players. This library used to be included in Wine, which allowed the audio to work, but it was removed in Wine 8 due to this library being deprecated, breaking audio in Proton 8 and later, and Valve has no plans to fix this. It is fortunately still able to be downloaded using Protontricks.

More details: https://github.com/ValveSoftware/Proton/issues/809#issuecomment-2427897314