### PR TITLE
Launch option workaround for Horizon Zero Dawn Remastered

### DIFF
--- a/gamefixes-steam/2561580.py
+++ b/gamefixes-steam/2561580.py
@@ -1,0 +1,11 @@
+"""Game fix for Horizon Zero Dawn Remastered"""
+
+from sys import argv
+from os import environ
+from protonfixes import util
+
+
+def main() -> None:
+	"""Won't connect to internet without using `-showlinkingqr` or `SteamDeck=1` options."""
+	if environ.get('SteamDeck', '0') == '0' and '-showlinkingqr' not in argv:
+		util.append_argument('-showlinkingqr')


### PR DESCRIPTION
The game is having trouble connecting to the internet to log into PSN account without using the `SteamDeck=1` or `-showlinkingqr` options.

Reason for using `-showlinkingqr` rather than `SteamDeck=1`: https://github.com/ValveSoftware/Proton/issues/8205#issuecomment-2450782191 - The game is already expected to work on Steam Deck due to using the latter by default.

[ProtonDB reports are also suggesting this workaround.](https://www.protondb.com/app/2561580?device=any)