### PR TITLE
Add Mod Support for some games

### DIFF
--- a/gamefixes-steam/1446780.py
+++ b/gamefixes-steam/1446780.py
@@ -1,0 +1,7 @@
+"""MONSTER HUNTER RISE"""
+
+from protonfixes import util
+
+
+def main() -> None:
+    util.winedll_override('dinput8', 'n,b')  # Enables REFramework to hook the game and enable Mods

--- a/gamefixes-steam/1966720.py
+++ b/gamefixes-steam/1966720.py
@@ -1,0 +1,7 @@
+"""Lethal Company"""
+
+from protonfixes import util
+
+
+def main() -> None:
+    util.winedll_override('winhttp', 'n,b')  # Adds BepInEx Support

--- a/gamefixes-steam/2225070.py
+++ b/gamefixes-steam/2225070.py
@@ -1,0 +1,7 @@
+"""Trackmania"""
+
+from protonfixes import util
+
+
+def main() -> None:
+    util.winedll_override('dinput8', 'n,b')  # Adds openplanet plugin manager Support

--- a/gamefixes-steam/322170.py
+++ b/gamefixes-steam/322170.py
@@ -1,0 +1,7 @@
+"""Geometry Dash"""
+
+from protonfixes import util
+
+
+def main() -> None:
+    util.winedll_override('xinput1_4', 'n,b')  # Adds Geode Mod Support


### PR DESCRIPTION
Hi there! I made some custom fixes for certain games to play them with mods some time ago. So far, I’ve only found four of these, but I remember making more that should still be somewhere on one of my disks.

This PR adds mod support for these games:
| Game Name            | Steam ID | What I Did                                | What It Does                                         |
|----------------------|----------|-------------------------------------------|------------------------------------------------------|
| Geometry Dash        | 322170   | Set `xinput1_4` to `(native, builtin)`    | Adds support for Geode Mods                          |
| MONSTER HUNTER RISE  | 1446780  | Set `dinput8` to `(native, builtin)`      | Enables REFramework to hook the game and enable mods |
| Lethal Company       | 1966720  | Set `winhttp` to `(native, builtin)`      | Adds BepInEx support                                 |
| Trackmania           | 2225070  | Set `dinput8` to `(native, builtin)`      | Adds Openplanet plugin manager support               |



            
