### PR TITLE
Add fix for dirt 3 outside of steam

### DIFF
--- a/gamefixes-umu/321040.py
+++ b/gamefixes-umu/321040.py
@@ -1,0 +1,1 @@
+/home/pollux/umu-protonfixes-dirt3/gamefixes-steam/321040.py

--- a/gamefixes-umu/321040.py
+++ b/gamefixes-umu/321040.py
@@ -1,1 +1,0 @@
-/home/pollux/umu-protonfixes-dirt3/gamefixes-steam/321040.py

--- a/gamefixes-umu/umu-321040.py
+++ b/gamefixes-umu/umu-321040.py
@@ -1,9 +1,1 @@
-"""Game fix for Dirt 3 Complete Edition"""
-
-
-from protonfixes import util
-
-
-def main() -> None:
-    """Installs OpenAL library, without it the game simply wont launch on proton 8 or above"""
-    util.protontricks('Openal')
+../gamefixes-steam/321040.py

--- a/gamefixes-umu/umu-321040.py
+++ b/gamefixes-umu/umu-321040.py
@@ -5,5 +5,5 @@ from protonfixes import util
 
 
 def main() -> None:
-    """Installs OpenAL library, without it the game simply wont launch on newer proton version"""
+    """Installs OpenAL library, without it the game simply wont launch on proton 8 or above"""
     util.protontricks('Openal')

--- a/gamefixes-umu/umu-321040.py
+++ b/gamefixes-umu/umu-321040.py
@@ -5,5 +5,5 @@ from protonfixes import util
 
 
 def main() -> None:
-    """Installs OpenAL library, without it the game simply wont launch on newer proton version's"""
+    """Installs OpenAL library, without it the game simply wont launch on newer proton version"""
     util.protontricks('Openal')

--- a/gamefixes-umu/umu-321040.py
+++ b/gamefixes-umu/umu-321040.py
@@ -1,0 +1,9 @@
+"""Game fix for Dirt 3 Complete Edition"""
+
+
+from protonfixes import util
+
+
+def main() -> None:
+    """Installs OpenAL library, without it the game simply wont launch on newer proton version's"""
+    util.protontricks('Openal')


### PR DESCRIPTION
Without this library (openal) dirt 3 wont launch on proton 8 or above outside of steam 

This is for running the game on its own with no store available 

Database pull request
https://github.com/Open-Wine-Components/umu-database/pull/50
