### PR TITLE
Remove no longer needed Disgaea 4 fix

### DIFF
--- a/gamefixes-steam/1233880.py
+++ b/gamefixes-steam/1233880.py
@@ -1,8 +1,0 @@
-"""Game fix for Disgaea 4 Complete+"""
-
-from protonfixes import util
-
-def main() -> None:
-	"""Usually won't reach menu unless Esync and Fsync are disabled"""
-	util.disable_esync()
-	util.disable_fsync()


### PR DESCRIPTION
This workaround has now been added to Proton Experimental.