### PR TITLE
Compatibity for "Teenage Mutant Ninja Turtles Shredders Revenge"

### DIFF
--- a/gamefixes-egs/umu-1361510.py
+++ b/gamefixes-egs/umu-1361510.py
@@ -1,0 +1,2 @@
+../gamefixes-steam/1361510.py
+# EGS a4977aac967e4e2c827336f074c82d64

--- a/gamefixes-egs/umu-1361510.py
+++ b/gamefixes-egs/umu-1361510.py
@@ -1,2 +1,1 @@
 ../gamefixes-steam/1361510.py
-# EGS a4977aac967e4e2c827336f074c82d64

--- a/gamefixes-steam/1361510.py
+++ b/gamefixes-steam/1361510.py
@@ -1,0 +1,8 @@
+"""Teenage Mutant Ninja Turtles Shredders Revenge"""
+
+from protonfixes import util
+
+
+def main() -> None:
+    # Requires vcrun2017 to launch
+    util.protontricks('vcrun2017')


### PR DESCRIPTION
Hi all!

On Steam, its ID is 1361510
On EGS, its Namespace is a4977aac967e4e2c827336f074c82d64 (https://egdata.app/sandboxes/a4977aac967e4e2c827336f074c82d64/offers)

Only is necesary "vcrun2017" ... although heroic Game Launcher fixes this way:
{
    "title": "Teenage Mutant Ninja Turtles: Shredder's Revenge",
    "notes": {
      "d3dcompiler_47": "Fix black window when displaying game launcher.",
      "vcrun2017": "Fix game not starting.",
      "dotnet46": "Fix game not starting (seems to not be needed for some systems, steamdeck needs this.)"
    },
    "winetricks": ["d3dcompiler_47", "vcrun2017", "dotnet46"]
  }
  
If I create a new prefix with UMU-launcher with UMU-proton or GE-Proton (I've checked both) and then I run:
_`WINEPREFIX="/home/deck/Prefix/Heroic/Teenage Mutant Ninja Turtles Shredders Revenge" GAMEID=0 /home/deck/Apps/umu-launcher/umu-run winetricks vcrun2017`_

The game runs good now. Otherwise, it will not start.