### PR TITLE
fixes: Remove redundant dinput8 overrides

### DIFF
--- a/gamefixes-gog/umu-1141086411.py
+++ b/gamefixes-gog/umu-1141086411.py
@@ -6,8 +6,5 @@ from protonfixes import util
 def main() -> None:
     util.winedll_override('d3d8', 'n,b')  # GOG's dxcfg / Steam006 fixes
     util.winedll_override(
-        'dinput8', 'n,b'
-    )  # GOG's controller fix / Silent Hill 4: Wrapper by Nemesis / ThirteenAG's widescreen fix
-    util.winedll_override(
         'dsound', 'n,b'
     )  # Ultimate ASI Loader / Silent Hill 4 Randomizer

--- a/gamefixes-steam/211420.py
+++ b/gamefixes-steam/211420.py
@@ -12,6 +12,5 @@ def main() -> None:
 
     # In case if someone wishes to use DSfix
     util.protontricks('dinput8')
-    util.winedll_override('dinput8', 'n')
 
     util.protontricks('win7')

--- a/gamefixes-steam/251150.py
+++ b/gamefixes-steam/251150.py
@@ -7,4 +7,3 @@ def main() -> None:
     util.protontricks('quartz')  # Cutscene fixes
     util.protontricks('amstream')
     util.protontricks('lavfilters')
-    util.winedll_override('dinput8', 'n,b')  # Set for the SoraVoice mod

--- a/gamefixes-steam/251290.py
+++ b/gamefixes-steam/251290.py
@@ -7,4 +7,3 @@ def main() -> None:
     util.protontricks('quartz')  # Cutscene fixes
     util.protontricks('amstream')
     util.protontricks('lavfilters')
-    util.winedll_override('dinput8', 'n,b')  # Set for the SoraVoice mod

--- a/gamefixes-steam/436670.py
+++ b/gamefixes-steam/436670.py
@@ -7,4 +7,3 @@ def main() -> None:
     util.protontricks('quartz')  # Cutscene fixes
     util.protontricks('amstream')
     util.protontricks('lavfilters')
-    util.winedll_override('dinput8', 'n,b')  # Set for the SoraVoice mod

--- a/gamefixes-steam/65540.py
+++ b/gamefixes-steam/65540.py
@@ -27,7 +27,6 @@ def main() -> None:
     # Gothic 1: https://steamcommunity.com/sharedfiles/filedetails/?id=3054112346
     # Gothic 2: https://steamcommunity.com/sharedfiles/filedetails/?id=3054078559
     util.winedll_override('dinput', 'n,b')
-    util.winedll_override('dinput8', 'n,b')
 
 
 def set_resolution() -> None:


### PR DESCRIPTION
dinput8 is now default n,b in Proton Bleeding Edge https://github.com/ValveSoftware/wine/commit/09af566a7fbaa075eaeaa76468c7344bdbeeafda

https://www.gog.com/en/game/silent_hill_4_the_room
https://github.com/ValveSoftware/Proton/issues/1319
https://github.com/ValveSoftware/Proton/issues/3570
https://github.com/ValveSoftware/Proton/issues/1079
https://github.com/ValveSoftware/Proton/issues/5120
https://github.com/ValveSoftware/Proton/issues/3245