### PR TITLE
Create fix for From Dust (33460)

### DIFF
--- a/gamefixes-steam/33460.py
+++ b/gamefixes-steam/33460.py
@@ -1,0 +1,9 @@
+"""Game fix for From Dust"""
+
+from protonfixes import util
+
+
+def main() -> None:
+	"""Game will get stuck on initial loading screen unless these are disabled"""
+	util.disable_esync()
+	util.disable_fsync()


### PR DESCRIPTION
Fix the loading issue for From Dust.

This is necessary for the game to run, as mentioned on [ProtonDB](https://www.protondb.com/app/33460?device=pc) and  [Proton GitHub.](https://github.com/ValveSoftware/Proton/issues/2513)