### PR TITLE
Remove exe redirect for Final Fantasy IX (377840)

### DIFF
--- a/gamefixes-steam/377840.py
+++ b/gamefixes-steam/377840.py
@@ -4,9 +4,5 @@ from protonfixes import util
 
 
 def main() -> None:
-    """Changes the proton argument from the launcher to the game"""
     # Fix crackling audio
     util.set_environment('PULSE_LATENCY_MSEC', '60')
-
-    # Replace launcher with game exe in proton arguments
-    util.replace_command('FF9_Launcher.exe', 'x64/FF9.exe')


### PR DESCRIPTION
Remove bypassing the launcher, launcher related issues have been fixed as noted on the [Proton Github](https://github.com/ValveSoftware/Proton/issues/708).

Bypassing the launcher also resulted in the game being unable to load correctly.