### PR TITLE
Remove `DXVK_NVAPI_GPU_ARCH` workaround for Indiana Jones and the Great Circle

### DIFF
--- a/gamefixes-steam/2677660.py
+++ b/gamefixes-steam/2677660.py
@@ -4,6 +4,5 @@ from protonfixes import util
 
 
 def main() -> None:
-    """Bad performance on Nvidia due to poor VRAM utilization"""
-    util.set_environment('DXVK_NVAPI_GPU_ARCH', 'GA100')
+    """Bad performance on Nvidia due to VRAM under-utilization"""
     util.set_environment('__GL_13ebad', '0x1')


### PR DESCRIPTION
[dxvk-nvapi 0.8](https://github.com/jp7677/dxvk-nvapi/releases/tag/v0.8.0), which is now available in proton bleeding edge, already includes the `DXVK_NVAPI_GPU_ARCH` workaround for this game, but the other variable is still needed.