### PR TITLE
Workaround around to prevent Sonic Colors Ultimate black screen for some users

### DIFF
--- a/gamefixes-steam/2055290.py
+++ b/gamefixes-steam/2055290.py
@@ -1,0 +1,8 @@
+"""Sonic Colors: Ultimate"""
+
+from protonfixes import util
+
+
+def main() -> None:
+    """Black screen for some users unless deleting XDG_DATA_HOME variable"""
+    util.del_environment('XDG_DATA_HOME')


### PR DESCRIPTION
I'm not smart enough to know what this is supposed to do, but apparently some people are having trouble with the game getting stuck on a black screen unless the `XDG_DATA_HOME` environment variable is removed.

https://github.com/ValveSoftware/Proton/issues/7538#issuecomment-2562077664