### PR TITLE
Add fix for Identity V

### DIFF
--- a/gamefixes-umu/umu-identityv.py
+++ b/gamefixes-umu/umu-identityv.py
@@ -1,0 +1,8 @@
+"""Game fix for Identity V"""
+
+from protonfixes import util
+
+
+def main() -> None:
+# Fixes black screen on first launch
+util.protontricks('d3dcompiler_47')

--- a/gamefixes-umu/umu-identityv.py
+++ b/gamefixes-umu/umu-identityv.py
@@ -4,5 +4,5 @@ from protonfixes import util
 
 
 def main() -> None:
-# Fixes black screen on first launch
-util.protontricks('d3dcompiler_47')
+    # Fixes black screen on first launch
+    util.protontricks('d3dcompiler_47')


### PR DESCRIPTION
Identity V is a game developed and published by NetEase. It is a mobile game with a PC "port" (mobile gameplay, but native executable).

https://en.wikipedia.org/wiki/Identity_V
https://idv.163.com/ (official website)

Has black screen on first launch and spams Proton log with `d3dcompiler`-related entries. Specifically, things related to `skip_u32_unknown`. Installing `d3dcompiler_47` fixes the problem.

Tested with `GE-Proton9-21`.

Game is standalone (has to be downloaded through their site).

Related umu-database PR: https://github.com/Open-Wine-Components/umu-database/pull/62