### PR TITLE
Add fix for BioShock Remastered and BioShock 2 Remastered (EGS)

### DIFF
--- a/gamefixes-egs/umu-409710.py
+++ b/gamefixes-egs/umu-409710.py
@@ -1,0 +1,1 @@
+../gamefixes-steam/409720.py

--- a/gamefixes-egs/umu-409720.py
+++ b/gamefixes-egs/umu-409720.py
@@ -1,0 +1,1 @@
+../gamefixes-steam/409720.py


### PR DESCRIPTION
Database PR: https://github.com/Open-Wine-Components/umu-database/pull/67

Continuation of https://github.com/Open-Wine-Components/umu-protonfixes/pull/176 covering the EGS copies of these games. 