### PR TITLE
Add directplay for Total Annihilation

### DIFF
--- a/gamefixes-steam/289030.py
+++ b/gamefixes-steam/289030.py
@@ -1,0 +1,8 @@
+"""Game fix for Total Annihilation"""
+
+from protonfixes import util
+
+
+def main() -> None:
+    """Multiplayer requires directplay for full functionality"""
+    util.protontricks('directplay')


### PR DESCRIPTION
When you select Multi and the TCP/IP the game goes back to the Multi menu without directplay.

With directplay it lets you host games and play successfully.