### PR TITLE
Set game drive for Epic Mickey 2

### DIFF
--- a/gamefixes-steam/245300.py
+++ b/gamefixes-steam/245300.py
@@ -1,0 +1,8 @@
+"""Epic Mickey 2"""
+
+from protonfixes import util
+
+
+def main() -> None:
+    """Green textures depending on where the game is installed."""
+    util.set_game_drive(True)


### PR DESCRIPTION
Game still has problems (namely in the form of green textures) depending on where it is installed. [ProtonDB reports](https://www.protondb.com/app/245300?device=any) are also consistent with this, i.e. the game only works on the Steam Deck when installed on an SD card and not the internal storage. Going by the latest report there, it looks like the issue is still there with 9.0-4.

This might be fixable by enabling game drive, according to https://github.com/ValveSoftware/Proton/issues/6670#issuecomment-2568215840 and the comments below it.