### PR TITLE
Install Ubisoft Connect for Ghost Recon Breakpoint

### DIFF
--- a/gamefixes-steam/2231380.py
+++ b/gamefixes-steam/2231380.py
@@ -1,0 +1,8 @@
+"""Tom Clancy's Ghost Recon Breakpoint"""
+
+from protonfixes import util
+
+
+def main() -> None:
+    """Game ships with outdated uPlay launcher, which will not install to be able to start the game"""
+    util.protontricks('ubisoftconnect')


### PR DESCRIPTION
Going by the latest ProtonDB reports, it looks like it still ships the wrong launcher.

https://github.com/ValveSoftware/Proton/issues/6471#issuecomment-1804015021