### PR TITLE
Revert "Set game drive for Epic Mickey 2"

### DIFF
--- a/gamefixes-steam/245300.py
+++ b/gamefixes-steam/245300.py
@@ -1,8 +1,0 @@
-"""Epic Mickey 2"""
-
-from protonfixes import util
-
-
-def main() -> None:
-    """Green textures depending on where the game is installed."""
-    util.set_game_drive(True)


### PR DESCRIPTION
Reverts Open-Wine-Components/umu-protonfixes#197

Fixed in https://github.com/ValveSoftware/Proton/commit/b0df23cb5ca4e4c9d6bb37dd58c2974fa50d2457