### PR TITLE
Refactor: Relative imports / imports without try block

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,10 @@ jobs:
           ln -s umu-protonfixes protonfixes
           cd protonfixes
           python3 .github/scripts/check_imports.py
+      # We need a known parent package in the unit tests, so we need to change to the parent dir
+      # As "umu-protonfixes" is not a valid package name, we create a symbolic link to "protonfixes"
       - name: Test with unittest
         run: |
-          python3 protonfixes_test.py
+          cd ..
+          ln -s umu-protonfixes protonfixes
+          python3 -m protonfixes.protonfixes_test

--- a/checks.py
+++ b/checks.py
@@ -1,9 +1,6 @@
 """Run some tests and generate warnings for proton configuration issues"""
 
-try:
-    from .logger import log
-except ImportError:
-    from logger import log
+from .logger import log
 
 
 def esync_file_limits() -> bool:

--- a/config.py
+++ b/config.py
@@ -1,12 +1,9 @@
 """Load configuration settings for protonfixes"""
 
 import os
-from configparser import ConfigParser
 
-try:
-    from .logger import log
-except ImportError:
-    from logger import log
+from configparser import ConfigParser
+from .logger import log
 
 
 CONF_FILE = '~/.config/protonfixes/config.ini'

--- a/engine.py
+++ b/engine.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+
 from .logger import log
 
 

--- a/fix.py
+++ b/fix.py
@@ -4,17 +4,13 @@ import os
 import re
 import sys
 import csv
+
 from functools import lru_cache
 from importlib import import_module
 
-try:
-    from . import config
-    from .checks import run_checks
-    from .logger import log
-except ImportError:
-    import config
-    from checks import run_checks
-    from logger import log
+from . import config
+from .checks import run_checks
+from .logger import log
 
 try:
     import __main__ as protonmain

--- a/gamefixes-egs/umu-1248080.py
+++ b/gamefixes-egs/umu-1248080.py
@@ -1,6 +1,6 @@
 """Game fix for CYGNI: All Guns Blazing"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-egs/umu-1370140.py
+++ b/gamefixes-egs/umu-1370140.py
@@ -1,6 +1,6 @@
 """Game fix Kao the Kangaroo (2022)"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-egs/umu-2138710.py
+++ b/gamefixes-egs/umu-2138710.py
@@ -1,6 +1,6 @@
 """Game fix for Sifu"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-egs/umu-2144740.py
+++ b/gamefixes-egs/umu-2144740.py
@@ -1,6 +1,6 @@
 """Game fix for Ghost Runner 2"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-egs/umu-2229940.py
+++ b/gamefixes-egs/umu-2229940.py
@@ -1,6 +1,6 @@
 """Game fix for [REDACTED]"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-egs/umu-517710.py
+++ b/gamefixes-egs/umu-517710.py
@@ -1,6 +1,6 @@
 """Game fix Redout: Enhanced Edition"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-egs/umu-976590.py
+++ b/gamefixes-egs/umu-976590.py
@@ -1,6 +1,6 @@
 """Game fix for Bus Simulator 21 Next Stop"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-egs/umu-990080.py
+++ b/gamefixes-egs/umu-990080.py
@@ -1,6 +1,6 @@
 """Game fix Hogwarts Legacy"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-gog/umu-1141086411.py
+++ b/gamefixes-gog/umu-1141086411.py
@@ -1,6 +1,6 @@
 """Silent Hill 4: The Room"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-gog/umu-1209310984.py
+++ b/gamefixes-gog/umu-1209310984.py
@@ -11,8 +11,8 @@ from hashlib import sha256
 from tempfile import mkdtemp
 from urllib.request import urlopen
 
-from protonfixes import util
-from protonfixes.logger import log
+from .. import util
+from ..logger import log
 
 
 def main() -> None:

--- a/gamefixes-gog/umu-1228964594.py
+++ b/gamefixes-gog/umu-1228964594.py
@@ -1,6 +1,6 @@
 """Game fix for Soldier of Fortune II: Double Helix - Gold Edition"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-gog/umu-1564851593.py
+++ b/gamefixes-gog/umu-1564851593.py
@@ -10,8 +10,8 @@ from tempfile import mkdtemp
 from urllib.request import urlopen
 from zipfile import ZipFile, is_zipfile
 
-from protonfixes import util
-from protonfixes.logger import log
+from .. import util
+from ..logger import log
 
 # Archive containing the text injecting framework
 arc = 'https://github.com/user-attachments/files/16136393/d3d9-2206220222.zip'

--- a/gamefixes-gog/umu-1580232252.py
+++ b/gamefixes-gog/umu-1580232252.py
@@ -1,6 +1,6 @@
 """Resident Evil (1997)"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-gog/umu-1584652180.py
+++ b/gamefixes-gog/umu-1584652180.py
@@ -1,6 +1,6 @@
 """The Wheel of Time"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-gog/umu-1771973390.py
+++ b/gamefixes-gog/umu-1771973390.py
@@ -1,6 +1,6 @@
 """METAL GEAR SOLID"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-gog/umu-2069117974.py
+++ b/gamefixes-gog/umu-2069117974.py
@@ -1,8 +1,7 @@
 """METAL GEAR SOLID 2 SUBSTANCE"""
 # GOG-ID 2069117974
 
-from protonfixes import util
-
+from .. import util
 
 def main() -> None:
     util.protontricks('dsound')

--- a/gamefixes-gog/umu-22610.py
+++ b/gamefixes-gog/umu-22610.py
@@ -1,6 +1,6 @@
 """Alien Breed: Impact"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-gog/umu-22650.py
+++ b/gamefixes-gog/umu-22650.py
@@ -1,6 +1,6 @@
 """Alien Breed 2: Assault"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-gog/umu-22670.py
+++ b/gamefixes-gog/umu-22670.py
@@ -1,6 +1,6 @@
 """Alien Breed 3: Descent"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/1017900.py
+++ b/gamefixes-steam/1017900.py
@@ -1,6 +1,6 @@
 """Game fix for Age of Empires: DE"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/10220.py
+++ b/gamefixes-steam/10220.py
@@ -1,6 +1,6 @@
 """Postal III"""
 
-from protonfixes import util
+from .. import util
 
 
 # Missing fonts for console and various UI

--- a/gamefixes-steam/1030830.py
+++ b/gamefixes-steam/1030830.py
@@ -1,6 +1,6 @@
 """Game fix for Mafia II Definitive Edition"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/105000.py
+++ b/gamefixes-steam/105000.py
@@ -3,7 +3,7 @@ https://github.com/ValveSoftware/Proton/issues/1412
 No cutscene audio in Daedalic Games (Memoria, The Night of the Rabbit, A New Beginning - Final Cut) (105000 230820 243200) #1412
 """
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/105400.py
+++ b/gamefixes-steam/105400.py
@@ -3,8 +3,8 @@
 import os
 import shutil
 
-from protonfixes import util
-from protonfixes.logger import log
+from .. import util
+from ..logger import log
 
 
 def main() -> None:

--- a/gamefixes-steam/105450.py
+++ b/gamefixes-steam/105450.py
@@ -1,6 +1,6 @@
 """Game fix for Age Of Empire 3: Complete Collection"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/1056640.py
+++ b/gamefixes-steam/1056640.py
@@ -1,6 +1,6 @@
 """Game fix for Phantasy Star Online 2"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/1062040.py
+++ b/gamefixes-steam/1062040.py
@@ -1,6 +1,6 @@
 """Dragon Star Varnir"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/1063730.py
+++ b/gamefixes-steam/1063730.py
@@ -1,6 +1,6 @@
 """Game fix for New World"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/108710.py
+++ b/gamefixes-steam/108710.py
@@ -1,6 +1,6 @@
 """Alan Wake"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/1097150.py
+++ b/gamefixes-steam/1097150.py
@@ -1,6 +1,6 @@
 """Game fix for Fall Guys"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/1097880.py
+++ b/gamefixes-steam/1097880.py
@@ -1,6 +1,6 @@
 """Game fix for Super Naughty Maid 2"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/1105510.py
+++ b/gamefixes-steam/1105510.py
@@ -1,6 +1,6 @@
 """Game fix for Yakuza 5"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/110800.py
+++ b/gamefixes-steam/110800.py
@@ -1,6 +1,6 @@
 """Game fix for L.A. Noire"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/1113000.py
+++ b/gamefixes-steam/1113000.py
@@ -1,6 +1,6 @@
 """Game fix for Persona 4 Golden"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/1121560.py
+++ b/gamefixes-steam/1121560.py
@@ -3,7 +3,7 @@ Missing voices/sounds in cutscenes
 Requires disabling the gstreamer protonaudioconverterbin plugin to get full audio in cutscenes
 """
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/1151640.py
+++ b/gamefixes-steam/1151640.py
@@ -1,6 +1,6 @@
 """Game fix for Horizon Zero Dawn"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/1158850.py
+++ b/gamefixes-steam/1158850.py
@@ -3,7 +3,7 @@ Missing sound in bonus content videos
 Requires disabling the gstreamer protonaudioconverterbin to get full audio
 """
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/1174180.py
+++ b/gamefixes-steam/1174180.py
@@ -1,6 +1,6 @@
 """Game fix for Red Dead Redemption 2"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/1175730.py
+++ b/gamefixes-steam/1175730.py
@@ -1,6 +1,6 @@
 """Game fix Tree Of Savior"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/12200.py
+++ b/gamefixes-steam/12200.py
@@ -1,6 +1,6 @@
 """Game fix for Bully: Scholarship Edition"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/12210.py
+++ b/gamefixes-steam/12210.py
@@ -1,6 +1,6 @@
 """Game fix for GTA IV"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/1222370.py
+++ b/gamefixes-steam/1222370.py
@@ -1,6 +1,6 @@
 """Necromunda: Hired Gun"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/1222690.py
+++ b/gamefixes-steam/1222690.py
@@ -1,6 +1,6 @@
 """Game fix for Dragon Age Inquisition"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/1230140.py
+++ b/gamefixes-steam/1230140.py
@@ -1,6 +1,6 @@
 """Game fix for ATRI -My Dear Moments-"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/1237970.py
+++ b/gamefixes-steam/1237970.py
@@ -3,7 +3,7 @@
 import os
 import subprocess
 import glob
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/1239520.py
+++ b/gamefixes-steam/1239520.py
@@ -1,6 +1,6 @@
 """Madden NFL 21 needs vcrun2019 for online mode to work"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/1240440.py
+++ b/gamefixes-steam/1240440.py
@@ -1,6 +1,6 @@
 """Halo Infinite needs vcrun2019"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/1245620.py
+++ b/gamefixes-steam/1245620.py
@@ -1,7 +1,7 @@
 """Game fix for Elden Ring: Create the `DLC.bdt` and `DLC.bhd` files to work around the "Inappropriate activity detected" error for players that don't own the DLC"""
 
 from pathlib import Path
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/1250410.py
+++ b/gamefixes-steam/1250410.py
@@ -1,6 +1,6 @@
 """Game fix for Flight Simulator 2020"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/1257290.py
+++ b/gamefixes-steam/1257290.py
@@ -3,7 +3,7 @@ Missing voices/sounds in cutscenes
 Requires disabling the gstreamer protonaudioconverterbin plugin to get full audio in cutscenes
 """
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/1259970.py
+++ b/gamefixes-steam/1259970.py
@@ -1,6 +1,6 @@
 """Game fix for Pes 2021"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/1272580.py
+++ b/gamefixes-steam/1272580.py
@@ -2,7 +2,7 @@
 No music
 """
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/1277510.py
+++ b/gamefixes-steam/1277510.py
@@ -1,6 +1,6 @@
 """Game fix for Re:ZERO -Starting Life in Another World- The Prophecy of the Throne"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/1277930.py
+++ b/gamefixes-steam/1277930.py
@@ -1,6 +1,6 @@
 """Game fix for Riddle Joker"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/12810.py
+++ b/gamefixes-steam/12810.py
@@ -1,6 +1,6 @@
 """Overlord II"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/12840.py
+++ b/gamefixes-steam/12840.py
@@ -1,6 +1,6 @@
 """Game fix for Dirt 2"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/1284210.py
+++ b/gamefixes-steam/1284210.py
@@ -1,7 +1,7 @@
 """Game fix for Guild Wars 2"""
 
 import os
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/1284410.py
+++ b/gamefixes-steam/1284410.py
@@ -1,6 +1,6 @@
 """GWENT: The Witcher Card Game"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/1286880.py
+++ b/gamefixes-steam/1286880.py
@@ -1,6 +1,6 @@
 """Ship Graveyard Simulator"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/1293820.py
+++ b/gamefixes-steam/1293820.py
@@ -1,6 +1,6 @@
 """Game fix for YOU and ME and HER: A Love Story"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/1293830.py
+++ b/gamefixes-steam/1293830.py
@@ -1,6 +1,6 @@
 """Forza Horizon 4"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/1361510.py
+++ b/gamefixes-steam/1361510.py
@@ -1,6 +1,6 @@
 """Teenage Mutant Ninja Turtles Shredders Revenge"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/1382330.py
+++ b/gamefixes-steam/1382330.py
@@ -4,7 +4,7 @@ Requires disabling the gstreamer protonaudioconverterbin plugin to get full audi
 fixed by Swish in Protondb
 """
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/1413480.py
+++ b/gamefixes-steam/1413480.py
@@ -4,7 +4,7 @@ Requires disabling the gstreamer protonaudioconverterbin plugin to get full audi
 fixed Persona 5 Strikers by Swish in Protondb
 """
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/1434950.py
+++ b/gamefixes-steam/1434950.py
@@ -1,7 +1,6 @@
 """Game fix HighFleet"""
 
-#
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/1449280.py
+++ b/gamefixes-steam/1449280.py
@@ -1,8 +1,8 @@
 """Game fix for Ghostbusters: The Video Game Remastered (2019)"""
 
 from pathlib import Path
-from protonfixes import util
-from protonfixes.logger import log
+from .. import util
+from ..logger import log
 
 
 def main() -> None:

--- a/gamefixes-steam/1500540.py
+++ b/gamefixes-steam/1500540.py
@@ -1,6 +1,6 @@
 """Hardwar"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/15130.py
+++ b/gamefixes-steam/15130.py
@@ -1,6 +1,6 @@
 """Game fix for Beyond Good and Evil"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/1532190.py
+++ b/gamefixes-steam/1532190.py
@@ -1,6 +1,6 @@
 """Game fix for Halo CE mod tools"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/1544020.py
+++ b/gamefixes-steam/1544020.py
@@ -1,6 +1,6 @@
 """The Callisto Protocol"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/1557480.py
+++ b/gamefixes-steam/1557480.py
@@ -1,6 +1,6 @@
 """Project MIKHAIL: A Muv-Luv War Story"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/15700.py
+++ b/gamefixes-steam/15700.py
@@ -1,6 +1,6 @@
 """Oddworld: Abe's Oddysee"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/15740.py
+++ b/gamefixes-steam/15740.py
@@ -1,6 +1,6 @@
 """Game fix for Oddworld: Munch's Oddysee"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/15750.py
+++ b/gamefixes-steam/15750.py
@@ -1,6 +1,6 @@
 """Oddworld: Stranger's Wrath HD"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/1613450.py
+++ b/gamefixes-steam/1613450.py
@@ -1,6 +1,6 @@
 """Game fix for Halo 2 mod tools"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/1659420.py
+++ b/gamefixes-steam/1659420.py
@@ -1,6 +1,6 @@
 """UNCHARTED: Legacy of Thieves Collection"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/1664350.py
+++ b/gamefixes-steam/1664350.py
@@ -1,6 +1,6 @@
 """Ship Graveyard Simulator Prologue"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/16700.py
+++ b/gamefixes-steam/16700.py
@@ -2,7 +2,7 @@
 Fixes Multiplayer
 """
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/16810.py
+++ b/gamefixes-steam/16810.py
@@ -1,6 +1,6 @@
 """Civilization IV: Colonization"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/1681970.py
+++ b/gamefixes-steam/1681970.py
@@ -1,6 +1,6 @@
 """神都不良探 Underdog Detective"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/1695791.py
+++ b/gamefixes-steam/1695791.py
@@ -1,6 +1,6 @@
 """Game fix for Halo 3 mod tools"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/1695793.py
+++ b/gamefixes-steam/1695793.py
@@ -3,7 +3,7 @@ Standalone and Sapien seem to work just fine without d3dcompiler_47 and msxml3, 
 - Oro, @orowith2os
 """
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/1695794.py
+++ b/gamefixes-steam/1695794.py
@@ -1,6 +1,6 @@
 """Game fix Halo 3: ODST mod tools"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/1711950.py
+++ b/gamefixes-steam/1711950.py
@@ -1,6 +1,6 @@
 """GWENT: Rogue Mage"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/1715130.py
+++ b/gamefixes-steam/1715130.py
@@ -1,6 +1,6 @@
 """Crysis Remastered"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/1795390.py
+++ b/gamefixes-steam/1795390.py
@@ -2,7 +2,7 @@
 Proton issue: https://github.com/ValveSoftware/Proton/issues/6645
 """
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/1829980.py
+++ b/gamefixes-steam/1829980.py
@@ -1,6 +1,6 @@
 """Game fix for Café Stella and the Reaper's Butterflies"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/1873170.py
+++ b/gamefixes-steam/1873170.py
@@ -11,8 +11,8 @@ import urllib.request
 import zipfile
 import subprocess
 import hashlib
-from protonfixes import util
-from protonfixes.logger import log
+from .. import util
+from ..logger import log
 
 
 def main() -> None:

--- a/gamefixes-steam/1930.py
+++ b/gamefixes-steam/1930.py
@@ -2,7 +2,7 @@
 https://www.protondb.com/app/1930
 """
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/1999770.py
+++ b/gamefixes-steam/1999770.py
@@ -3,7 +3,7 @@ Missing voices/sounds in cutscenes
 Requires disabling the gstreamer protonaudioconverterbin plugin to get full audio in cutscenes
 """
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/200490.py
+++ b/gamefixes-steam/200490.py
@@ -3,7 +3,7 @@ wmp11 (Fixes missing logo videos and problems with working videos)
 hangs on logo without override
 """
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/200940.py
+++ b/gamefixes-steam/200940.py
@@ -1,6 +1,6 @@
 """Game fix for Sonic CD"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/201480.py
+++ b/gamefixes-steam/201480.py
@@ -1,6 +1,6 @@
 """Game fix for Serious Sam: The Random Encounter"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/204450.py
+++ b/gamefixes-steam/204450.py
@@ -1,6 +1,6 @@
 """Game fix for Call of Juarez: Gunslinger"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/205230.py
+++ b/gamefixes-steam/205230.py
@@ -1,6 +1,6 @@
 """Hell Yeah!"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/206480.py
+++ b/gamefixes-steam/206480.py
@@ -1,7 +1,6 @@
 """Game fix Dungeons & Dragons Online"""
 
-#
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/206500.py
+++ b/gamefixes-steam/206500.py
@@ -1,6 +1,6 @@
 """Game fix for AirMech Strike"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/207350.py
+++ b/gamefixes-steam/207350.py
@@ -1,6 +1,6 @@
 """Game fix for Ys Origin"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/208650.py
+++ b/gamefixes-steam/208650.py
@@ -1,6 +1,6 @@
 """Game fix for Batman Arkham Knight"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/211420.py
+++ b/gamefixes-steam/211420.py
@@ -1,6 +1,6 @@
 """Game fix Dark Souls Prepare To Die Edition"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/212500.py
+++ b/gamefixes-steam/212500.py
@@ -1,7 +1,6 @@
 """Game fix The Lord of the Rings Online"""
 
-#
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/213330.py
+++ b/gamefixes-steam/213330.py
@@ -1,6 +1,6 @@
 """Game fix for LEGO Batman 2: DC Super Heroes"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/2138090.py
+++ b/gamefixes-steam/2138090.py
@@ -5,7 +5,7 @@ fixed by Swish in Protondb
 further stolen from marianoag by bitwolf
 """
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/214510.py
+++ b/gamefixes-steam/214510.py
@@ -1,6 +1,6 @@
 """Game fix for LEGO The Lord of the Rings"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/214950.py
+++ b/gamefixes-steam/214950.py
@@ -1,6 +1,6 @@
 """Game fix for Total War: Rome II"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/215280.py
+++ b/gamefixes-steam/215280.py
@@ -1,6 +1,6 @@
 """Game fix for Secret World Legends"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/21680.py
+++ b/gamefixes-steam/21680.py
@@ -1,6 +1,6 @@
 """Bionic Commander Rearmed"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/2183070.py
+++ b/gamefixes-steam/2183070.py
@@ -1,6 +1,6 @@
 """Game fix for Tokyo Necro"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/219030.py
+++ b/gamefixes-steam/219030.py
@@ -1,6 +1,6 @@
 """Game fix for Ys Origin Demo"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/219990.py
+++ b/gamefixes-steam/219990.py
@@ -1,6 +1,6 @@
 """Game fix for Grim Dawn"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/220240.py
+++ b/gamefixes-steam/220240.py
@@ -1,6 +1,6 @@
 """FarCry 3"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/2229850.py
+++ b/gamefixes-steam/2229850.py
@@ -2,8 +2,8 @@
 
 import os
 
-from protonfixes import util
-from protonfixes.logger import log
+from .. import util
+from ..logger import log
 
 
 def main() -> None:

--- a/gamefixes-steam/2231380.py
+++ b/gamefixes-steam/2231380.py
@@ -1,6 +1,6 @@
 """Tom Clancy's Ghost Recon Breakpoint"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/22330.py
+++ b/gamefixes-steam/22330.py
@@ -12,7 +12,7 @@
 import os
 
 from dataclasses import dataclass
-from protonfixes import util
+from .. import util
 
 
 def main_with_id(game_id: str) -> None:

--- a/gamefixes-steam/223750.py
+++ b/gamefixes-steam/223750.py
@@ -1,6 +1,6 @@
 """Fixes for DCS World Steam Edition"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/224960.py
+++ b/gamefixes-steam/224960.py
@@ -1,6 +1,6 @@
 """Game fix for Tomb Raider I"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/225640.py
+++ b/gamefixes-steam/225640.py
@@ -1,6 +1,6 @@
 """Game fix for Sacred 2 Gold"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/227320.py
+++ b/gamefixes-steam/227320.py
@@ -1,6 +1,6 @@
 """Game fix for You Need a Budget 4"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/230820.py
+++ b/gamefixes-steam/230820.py
@@ -3,7 +3,7 @@ https://github.com/ValveSoftware/Proton/issues/1412
 No cutscene audio in Daedalic Games (Memoria, The Night of the Rabbit, A New Beginning - Final Cut) (105000 230820 243200) #1412
 """
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/231990.py
+++ b/gamefixes-steam/231990.py
@@ -1,7 +1,6 @@
 """Game fix for Spider-Man: Shattered Dimensions"""
 
-#
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/2322010.py
+++ b/gamefixes-steam/2322010.py
@@ -2,7 +2,7 @@
 Will not launch without SteamDeck=1
 """
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/233270.py
+++ b/gamefixes-steam/233270.py
@@ -1,6 +1,6 @@
 """Far Cry Blood Dragon"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/23460.py
+++ b/gamefixes-steam/23460.py
@@ -5,7 +5,7 @@ Videos still don't work.
 
 import os
 import subprocess
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/237890.py
+++ b/gamefixes-steam/237890.py
@@ -1,6 +1,6 @@
 """Game fix for Agarest: Generations of War"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/2399220.py
+++ b/gamefixes-steam/2399220.py
@@ -1,6 +1,6 @@
 """Game fix for NUKITASHI"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/240600.py
+++ b/gamefixes-steam/240600.py
@@ -1,6 +1,6 @@
 """Game fix for MotorGP"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/242760.py
+++ b/gamefixes-steam/242760.py
@@ -1,6 +1,6 @@
 """Game fix for The Forest"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/243200.py
+++ b/gamefixes-steam/243200.py
@@ -3,7 +3,7 @@ https://github.com/ValveSoftware/Proton/issues/1412
 No cutscene audio in Daedalic Games (Memoria, The Night of the Rabbit, A New Beginning - Final Cut) (105000 230820 243200) #1412
 """
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/244210.py
+++ b/gamefixes-steam/244210.py
@@ -1,6 +1,6 @@
 """Game fix for Assetto Corsa"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/244850.py
+++ b/gamefixes-steam/244850.py
@@ -1,6 +1,6 @@
 """Game fix for Space Engineers"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/2458530.py
+++ b/gamefixes-steam/2458530.py
@@ -1,6 +1,6 @@
 """Game fix for Sanoba Witch FHD Edition"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/2475980.py
+++ b/gamefixes-steam/2475980.py
@@ -6,7 +6,7 @@ import os
 import sys
 import subprocess
 import glob
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/2507620.py
+++ b/gamefixes-steam/2507620.py
@@ -1,6 +1,6 @@
 """Game fix for The Quintessential Quintuplets - Five Memories Spent With You"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/251150.py
+++ b/gamefixes-steam/251150.py
@@ -1,6 +1,6 @@
 """Game fix for The Legend of Heroes: Trails in the Sky"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/251290.py
+++ b/gamefixes-steam/251290.py
@@ -1,6 +1,6 @@
 """Game fix for The Legend of Heroes: Trails in the Sky SC"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/252430.py
+++ b/gamefixes-steam/252430.py
@@ -1,6 +1,6 @@
 """Game fix for Dusty Revenge: Co-Op Edition"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/2552430.py
+++ b/gamefixes-steam/2552430.py
@@ -1,6 +1,6 @@
 """Game fix for KINGDOM HEARTS -HD 1.5+2.5 ReMIX-"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/2561580.py
+++ b/gamefixes-steam/2561580.py
@@ -2,7 +2,7 @@
 
 from sys import argv
 from os import environ
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/256330.py
+++ b/gamefixes-steam/256330.py
@@ -1,6 +1,6 @@
 """WRC 4"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/260130.py
+++ b/gamefixes-steam/260130.py
@@ -1,6 +1,6 @@
 """Game fix for Agarest Zero"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/261510.py
+++ b/gamefixes-steam/261510.py
@@ -1,6 +1,6 @@
 """Game fix for Tesla Effect"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/2620.py
+++ b/gamefixes-steam/2620.py
@@ -1,6 +1,6 @@
 """Game fix for Call of Duty (2003)"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/266840.py
+++ b/gamefixes-steam/266840.py
@@ -2,7 +2,7 @@
 Source: https://github.com/JamesHealdUK/protonfixes/blob/master/fixes/266840.sh
 """
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/2677660.py
+++ b/gamefixes-steam/2677660.py
@@ -1,6 +1,6 @@
 """Game fix for Indiana Jones and the Great Circle"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/268050.py
+++ b/gamefixes-steam/268050.py
@@ -1,6 +1,6 @@
 """Game fix for The Evil Within(268050)"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/271590.py
+++ b/gamefixes-steam/271590.py
@@ -1,7 +1,7 @@
 """Game fix for GTAV"""
 
 import os
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/282900.py
+++ b/gamefixes-steam/282900.py
@@ -2,7 +2,7 @@
 Poor performance on some AMD hardware
 """
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/284160.py
+++ b/gamefixes-steam/284160.py
@@ -1,6 +1,6 @@
 """Game fix for BeamNG.drive"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/286360.py
+++ b/gamefixes-steam/286360.py
@@ -3,7 +3,7 @@ Launcher keeps it's process running in the background but nothing shows up
 """
 
 import os
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/287310.py
+++ b/gamefixes-steam/287310.py
@@ -1,6 +1,6 @@
 """Game fix for Re-Volt (287310)"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/287450.py
+++ b/gamefixes-steam/287450.py
@@ -2,7 +2,7 @@
 Source: https://github.com/simons-public/protonfixes/issues/24#issue-372384148
 """
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/289130.py
+++ b/gamefixes-steam/289130.py
@@ -1,6 +1,6 @@
 """Game fix for Endless Legend"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/292410.py
+++ b/gamefixes-steam/292410.py
@@ -1,6 +1,6 @@
 """Street Racing Syndicate"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/294700.py
+++ b/gamefixes-steam/294700.py
@@ -1,7 +1,7 @@
 """Game fix for Putt-Putt: Pep's Birthday Surprise"""
 
 import os
-from protonfixes import util
+from .. import util
 
 
 # Putt-Putt: PBS doesn't run unless there is a CD-ROM drive attached.

--- a/gamefixes-steam/298030.py
+++ b/gamefixes-steam/298030.py
@@ -1,6 +1,6 @@
 """Game fix for Total Annihilation"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/298110.py
+++ b/gamefixes-steam/298110.py
@@ -1,6 +1,6 @@
 """FarCry 4"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/302370.py
+++ b/gamefixes-steam/302370.py
@@ -6,7 +6,7 @@ edit registry to avoid ffdshow compatibility manager popup
 
 import os
 import subprocess
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/307780.py
+++ b/gamefixes-steam/307780.py
@@ -1,6 +1,6 @@
 """Game fix for Mortal Kombat X"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/311210.py
+++ b/gamefixes-steam/311210.py
@@ -1,6 +1,6 @@
 """Game fix for Black Ops III"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/311730.py
+++ b/gamefixes-steam/311730.py
@@ -1,6 +1,6 @@
 """Game fix for DEAD OR ALIVE 5 Last Round"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/312060.py
+++ b/gamefixes-steam/312060.py
@@ -1,7 +1,7 @@
 """Game fix for FFXIV"""
 
 import os
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/312450.py
+++ b/gamefixes-steam/312450.py
@@ -2,7 +2,7 @@
 Still missing intro video codecs
 """
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/312670.py
+++ b/gamefixes-steam/312670.py
@@ -1,6 +1,6 @@
 """Game fix for Strange Brigade"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/312790.py
+++ b/gamefixes-steam/312790.py
@@ -1,6 +1,6 @@
 """Game fix for Agarest: Generations of War 2"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/321040.py
+++ b/gamefixes-steam/321040.py
@@ -1,6 +1,6 @@
 """Game fix for Dirt 3 Complete Edition"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/328500.py
+++ b/gamefixes-steam/328500.py
@@ -1,7 +1,7 @@
 """Game fix for Potatoman Seeks the Troof"""
 
 import os
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/329380.py
+++ b/gamefixes-steam/329380.py
@@ -1,7 +1,7 @@
 """Game fix Stealth Inc 2: A Game of Clones"""
 
-from protonfixes import util
-from protonfixes.logger import log
+from .. import util
+from ..logger import log
 
 
 def main() -> None:

--- a/gamefixes-steam/331370.py
+++ b/gamefixes-steam/331370.py
@@ -1,6 +1,6 @@
 """Game fix for Dauntless"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/33230.py
+++ b/gamefixes-steam/33230.py
@@ -1,6 +1,6 @@
 """Game fix for Assassin's Creed 2"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/33460.py
+++ b/gamefixes-steam/33460.py
@@ -1,6 +1,6 @@
 """Game fix for From Dust"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/33990.py
+++ b/gamefixes-steam/33990.py
@@ -3,7 +3,7 @@ wmp11 (Fixes missing logo videos and problems with working videos)
 hangs on logo without override
 """
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/34330.py
+++ b/gamefixes-steam/34330.py
@@ -1,6 +1,6 @@
 """Total War: Shogun 2"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/348550.py
+++ b/gamefixes-steam/348550.py
@@ -1,6 +1,6 @@
 """Game fix for Guilty Gear Accent Core Plus R"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/35000.py
+++ b/gamefixes-steam/35000.py
@@ -1,6 +1,6 @@
 """Game fix for Mini Ninjas"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/35140.py
+++ b/gamefixes-steam/35140.py
@@ -2,7 +2,7 @@
 (Currently no contollers)
 """
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/351710.py
+++ b/gamefixes-steam/351710.py
@@ -2,7 +2,7 @@
 Poor performance on some AMD hardware
 """
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/356190.py
+++ b/gamefixes-steam/356190.py
@@ -1,6 +1,6 @@
 """Game fix Shadow of War"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/356500.py
+++ b/gamefixes-steam/356500.py
@@ -1,6 +1,6 @@
 """Game fix for STAR WARS Galactic Battlegrounds Saga"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/3590.py
+++ b/gamefixes-steam/3590.py
@@ -2,7 +2,7 @@
 Source: https://github.com/JamesHealdUK/protonfixes/blob/master/fixes/3590.sh
 """
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/359550.py
+++ b/gamefixes-steam/359550.py
@@ -1,6 +1,6 @@
 """Rainbow Six Siege"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/359870.py
+++ b/gamefixes-steam/359870.py
@@ -1,7 +1,7 @@
 """Game fix for FFX/X-2 HD Remaster"""
 
 import os
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/366250.py
+++ b/gamefixes-steam/366250.py
@@ -1,6 +1,6 @@
 """Metal Slug"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/368500.py
+++ b/gamefixes-steam/368500.py
@@ -1,6 +1,6 @@
 """Game fix for Assassin's Creed: Syndicate"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/371660.py
+++ b/gamefixes-steam/371660.py
@@ -1,6 +1,6 @@
 """Far Cry Primal"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/372000.py
+++ b/gamefixes-steam/372000.py
@@ -1,6 +1,6 @@
 """Game fix Tree Of Savior"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/375900.py
+++ b/gamefixes-steam/375900.py
@@ -1,6 +1,6 @@
 """Game fix for Trackmania Turbo"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/377840.py
+++ b/gamefixes-steam/377840.py
@@ -1,6 +1,6 @@
 """Game fix for FINAL FANTASY IX"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/378630.py
+++ b/gamefixes-steam/378630.py
@@ -3,7 +3,7 @@ Launcher keeps it's process running in the background but nothing shows up
 """
 
 import os
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/379720.py
+++ b/gamefixes-steam/379720.py
@@ -5,7 +5,7 @@ import shutil
 import urllib.request
 import zipfile
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/386360.py
+++ b/gamefixes-steam/386360.py
@@ -3,7 +3,7 @@
 import glob
 import os
 import subprocess
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/388750.py
+++ b/gamefixes-steam/388750.py
@@ -1,6 +1,6 @@
 """Game fix for Chronophantasma Extend"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/390710.py
+++ b/gamefixes-steam/390710.py
@@ -1,6 +1,6 @@
 """Game fix for SUGURI 2"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/39190.py
+++ b/gamefixes-steam/39190.py
@@ -1,6 +1,6 @@
 """Game fix for Dungeon Siege"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/39200.py
+++ b/gamefixes-steam/39200.py
@@ -1,6 +1,6 @@
 """Game fix for Dungeon Siege II"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/39210.py
+++ b/gamefixes-steam/39210.py
@@ -1,7 +1,7 @@
 """Game fix for FFXIV"""
 
 import os
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/39500.py
+++ b/gamefixes-steam/39500.py
@@ -1,7 +1,7 @@
 """Game fix for Gothic 3"""
 
 import os
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/39540.py
+++ b/gamefixes-steam/39540.py
@@ -1,6 +1,6 @@
 """Game fix for SpellForce"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/39690.py
+++ b/gamefixes-steam/39690.py
@@ -1,6 +1,6 @@
 """Game fix for Arkania"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/397540.py
+++ b/gamefixes-steam/397540.py
@@ -1,6 +1,6 @@
 """Game fix for Borderlands 3"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/40800.py
+++ b/gamefixes-steam/40800.py
@@ -1,7 +1,6 @@
 """Game fix for Super Meat Boy"""
 
-#
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/409090.py
+++ b/gamefixes-steam/409090.py
@@ -8,7 +8,7 @@ copy dgvoodoo2 d3d9.dll every time otherwise it gets overwritten
 import os
 import subprocess
 import shutil
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/40950.py
+++ b/gamefixes-steam/40950.py
@@ -2,7 +2,7 @@
 Fixes Multiplayer
 """
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/40970.py
+++ b/gamefixes-steam/40970.py
@@ -2,7 +2,7 @@
 Fixes Multiplayer
 """
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/409720.py
+++ b/gamefixes-steam/409720.py
@@ -1,6 +1,6 @@
 """Game fix for BioShock 2 Remastered"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/410900.py
+++ b/gamefixes-steam/410900.py
@@ -1,6 +1,6 @@
 """Game fix for Forts"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/424840.py
+++ b/gamefixes-steam/424840.py
@@ -1,6 +1,6 @@
 """Game fix for Little Nightmares"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/428660.py
+++ b/gamefixes-steam/428660.py
@@ -1,6 +1,6 @@
 """Deliver us the Moon fix"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/429720.py
+++ b/gamefixes-steam/429720.py
@@ -2,7 +2,7 @@
 
 import os
 import getpass
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/43110.py
+++ b/gamefixes-steam/43110.py
@@ -1,6 +1,6 @@
 """Game fix for Metro 2033"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/434570.py
+++ b/gamefixes-steam/434570.py
@@ -1,6 +1,6 @@
 """Game fix for Blood and Bacon"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/436670.py
+++ b/gamefixes-steam/436670.py
@@ -1,6 +1,6 @@
 """Game fix for The Legend of Heroes: Trails in the Sky the 3rd"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/440900.py
+++ b/gamefixes-steam/440900.py
@@ -1,6 +1,6 @@
 """Game fix for Conan Exiles"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/44690.py
+++ b/gamefixes-steam/44690.py
@@ -1,6 +1,6 @@
 """Game fix for GT Legends"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/447040.py
+++ b/gamefixes-steam/447040.py
@@ -1,6 +1,6 @@
 """Game fix for Watch_Dogs 2"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/452440.py
+++ b/gamefixes-steam/452440.py
@@ -11,8 +11,8 @@ from hashlib import sha256
 from subprocess import run
 
 import __main__ as protonmain
-from protonfixes import util
-from protonfixes.logger import log
+from .. import util
+from ..logger import log
 
 
 def main() -> None:

--- a/gamefixes-steam/45750.py
+++ b/gamefixes-steam/45750.py
@@ -4,7 +4,7 @@ This game requires two fixes to work:
 2. No more than 12 CPU cores (on PCGamingWiki is described as 6, but on my personal test I was able to set until 12 of 16) [source: https://www.pcgamingwiki.com/wiki/Lost_Planet_2#Alternate_solution_for_high_core_CPUs]
 """
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/460120.py
+++ b/gamefixes-steam/460120.py
@@ -1,7 +1,6 @@
 """Game fix for Megadimension Neptunia VII"""
 
-#
-from protonfixes import util
+from .. import util
 
 
 # Fixes cinematics not showing or spawning in a different window

--- a/gamefixes-steam/465280.py
+++ b/gamefixes-steam/465280.py
@@ -1,6 +1,6 @@
 """Game fix for Yesterday Origins"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/465840.py
+++ b/gamefixes-steam/465840.py
@@ -1,6 +1,6 @@
 """The Last Blade"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/4730.py
+++ b/gamefixes-steam/4730.py
@@ -1,6 +1,6 @@
 """Outrun 2006: Coast 2 Coast"""
 
-from protonfixes import util
+from .. import util
 
 
 # Fix water rendering as black

--- a/gamefixes-steam/48190.py
+++ b/gamefixes-steam/48190.py
@@ -3,7 +3,7 @@
 Game uses an old customized Ubisoft launcher that's currently not working with Proton.
 """
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/49520.py
+++ b/gamefixes-steam/49520.py
@@ -1,6 +1,6 @@
 """Game fix for Borderlands 2"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/495420.py
+++ b/gamefixes-steam/495420.py
@@ -1,6 +1,6 @@
 """Game fix for State of Decay 2"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/497360.py
+++ b/gamefixes-steam/497360.py
@@ -8,7 +8,7 @@ Widescreen supported (16:9/21:9, 32:9 not tested)
 
 import os
 import subprocess
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/49900.py
+++ b/gamefixes-steam/49900.py
@@ -1,6 +1,6 @@
 """Game fix for Plain Sight"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/508980.py
+++ b/gamefixes-steam/508980.py
@@ -1,7 +1,7 @@
 """Game fix for Crashday Redline Edition"""
 
 import json
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/518790.py
+++ b/gamefixes-steam/518790.py
@@ -1,6 +1,6 @@
 """The Hunter: Call of the Wild"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/550340.py
+++ b/gamefixes-steam/550340.py
@@ -1,6 +1,6 @@
 """Ougon Musoukyoku"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/559620.py
+++ b/gamefixes-steam/559620.py
@@ -1,7 +1,6 @@
 """Game fix for Outlaws + A Handful of Missions"""
 
-#
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/570940.py
+++ b/gamefixes-steam/570940.py
@@ -1,6 +1,6 @@
 """Game fix Dark Souls Remastered"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/582660.py
+++ b/gamefixes-steam/582660.py
@@ -1,7 +1,7 @@
 """Game fix for Black Desert Online"""
 
 import os
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/586140.py
+++ b/gamefixes-steam/586140.py
@@ -3,7 +3,7 @@ Missing voices/sounds in cutscenes
 Requires disabling the gstreamer protonaudioconverterbin plugin to get full audio in cutscenes
 """
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/593600.py
+++ b/gamefixes-steam/593600.py
@@ -1,6 +1,6 @@
 """Game fix for PixARK"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/601510.py
+++ b/gamefixes-steam/601510.py
@@ -1,6 +1,6 @@
 """Yu-Gi-Oh Duel Links needs vcrun2019"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/61500.py
+++ b/gamefixes-steam/61500.py
@@ -1,6 +1,6 @@
 """Game fix for Age of Wonders"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/6270.py
+++ b/gamefixes-steam/6270.py
@@ -1,6 +1,6 @@
 """Ducati World Championship"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/627270.py
+++ b/gamefixes-steam/627270.py
@@ -1,6 +1,6 @@
 """Game fix Injustice 2"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/63110.py
+++ b/gamefixes-steam/63110.py
@@ -2,7 +2,7 @@
 Launcher crashes immediately without displaying any windows
 """
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/633230.py
+++ b/gamefixes-steam/633230.py
@@ -1,6 +1,6 @@
 """Game fix for Naruto To Boruto"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/63700.py
+++ b/gamefixes-steam/63700.py
@@ -1,6 +1,6 @@
 """Game fix for BIT.TRIP BEAT"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/63710.py
+++ b/gamefixes-steam/63710.py
@@ -1,6 +1,6 @@
 """Game fix for BIT.TRIP RUNNER"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/638160.py
+++ b/gamefixes-steam/638160.py
@@ -1,6 +1,6 @@
 """Game fix for Moero Chronicle"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/638970.py
+++ b/gamefixes-steam/638970.py
@@ -1,6 +1,6 @@
 """Game fix for Yakuza 0"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/644930.py
+++ b/gamefixes-steam/644930.py
@@ -1,6 +1,6 @@
 """They Are Billions"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/65540.py
+++ b/gamefixes-steam/65540.py
@@ -2,7 +2,7 @@
 Game fix for Gothic II: Gold Classic
 """
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/65600.py
+++ b/gamefixes-steam/65600.py
@@ -1,7 +1,7 @@
 """Game fix for Gothic 3 Forsaken Gods Enhanced Edition"""
 
 import os
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/65610.py
+++ b/gamefixes-steam/65610.py
@@ -1,6 +1,6 @@
 """Game fix for Arkania"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/658150.py
+++ b/gamefixes-steam/658150.py
@@ -1,6 +1,6 @@
 """Skeleton Boomerang"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/658260.py
+++ b/gamefixes-steam/658260.py
@@ -2,7 +2,7 @@
 Missing voices/sounds in cutscenes
 """
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/65930.py
+++ b/gamefixes-steam/65930.py
@@ -1,6 +1,6 @@
 """Game fix for The Bureau: XCOM Declassified"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/678950.py
+++ b/gamefixes-steam/678950.py
@@ -1,6 +1,6 @@
 """Game fix for DRAGON BALL FighterZ"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/700600.py
+++ b/gamefixes-steam/700600.py
@@ -1,6 +1,6 @@
 """Game fix for Evil Genius 2"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/702050.py
+++ b/gamefixes-steam/702050.py
@@ -1,6 +1,6 @@
 """Game fix for The Song of Saya"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/70400.py
+++ b/gamefixes-steam/70400.py
@@ -1,6 +1,6 @@
 """Game fix for Recettear: An Item Shop's Tale"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/70420.py
+++ b/gamefixes-steam/70420.py
@@ -1,6 +1,6 @@
 """Game fix for Chantelise - A Tale of Two Sisters"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/70650.py
+++ b/gamefixes-steam/70650.py
@@ -1,6 +1,6 @@
 """Game fix for Worms: Blast"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/729040.py
+++ b/gamefixes-steam/729040.py
@@ -1,6 +1,6 @@
 """Borderlands GOTY"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/730830.py
+++ b/gamefixes-steam/730830.py
@@ -2,7 +2,7 @@
 dgvoodoo2 to force anti-aliasing and higher resolution
 """
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/73170.py
+++ b/gamefixes-steam/73170.py
@@ -1,6 +1,6 @@
 """Game fix for Darkest Hour: A Hearts of Iron Game"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/740550.py
+++ b/gamefixes-steam/740550.py
@@ -1,6 +1,6 @@
 """Game fix for Record of Agarest War Mariage"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/750920.py
+++ b/gamefixes-steam/750920.py
@@ -1,6 +1,6 @@
 """Shadow of the Tomb Raider"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/773370.py
+++ b/gamefixes-steam/773370.py
@@ -1,6 +1,6 @@
 """Exo One"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/78000.py
+++ b/gamefixes-steam/78000.py
@@ -1,6 +1,6 @@
 """Game fix for Bejeweled 3"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/782330.py
+++ b/gamefixes-steam/782330.py
@@ -1,6 +1,6 @@
 """DOOM Eternal"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/7850.py
+++ b/gamefixes-steam/7850.py
@@ -1,6 +1,6 @@
 """Game fix for Cryostasis"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/812140.py
+++ b/gamefixes-steam/812140.py
@@ -1,6 +1,6 @@
 """Assassin's Creed: Odyssey"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/813780.py
+++ b/gamefixes-steam/813780.py
@@ -1,6 +1,6 @@
 """Game fix Age of Empires II: DE"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/816020.py
+++ b/gamefixes-steam/816020.py
@@ -1,6 +1,6 @@
 """Game fix for JUMP FORCE"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/8190.py
+++ b/gamefixes-steam/8190.py
@@ -1,6 +1,6 @@
 """Just Cause 2"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/834530.py
+++ b/gamefixes-steam/834530.py
@@ -1,6 +1,6 @@
 """Game fix for Yakuza Kiwami"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/888790.py
+++ b/gamefixes-steam/888790.py
@@ -1,6 +1,6 @@
 """Game fix for Sabbat of the Witch"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/893180.py
+++ b/gamefixes-steam/893180.py
@@ -1,6 +1,6 @@
 """Game fix Catherine Classic"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/895870.py
+++ b/gamefixes-steam/895870.py
@@ -1,6 +1,6 @@
 """Project Wingman"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/906510.py
+++ b/gamefixes-steam/906510.py
@@ -1,6 +1,6 @@
 """Game fix for Conception PLUS: Maidens of the Twelve Stars"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/910830.py
+++ b/gamefixes-steam/910830.py
@@ -1,6 +1,6 @@
 """Game fix for Rebel Galaxy Outlaw"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/913740.py
+++ b/gamefixes-steam/913740.py
@@ -1,6 +1,6 @@
 """Game fix for WORLD OF HORROR"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/9350.py
+++ b/gamefixes-steam/9350.py
@@ -1,6 +1,6 @@
 """Game fix for Supreme Commander"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/936160.py
+++ b/gamefixes-steam/936160.py
@@ -5,7 +5,7 @@ fixed by Swish in Protondb
 further stolen from marianoag by bitwolf
 """
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/950670.py
+++ b/gamefixes-steam/950670.py
@@ -1,8 +1,8 @@
 """Game fix for Gothic Playable Teaser"""
 
 from pathlib import Path
-from protonfixes import util
-from protonfixes.logger import log
+from .. import util
+from ..logger import log
 
 
 def main() -> None:

--- a/gamefixes-steam/955050.py
+++ b/gamefixes-steam/955050.py
@@ -1,6 +1,6 @@
 """Bright Memory"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/963930.py
+++ b/gamefixes-steam/963930.py
@@ -1,6 +1,6 @@
 """Contractors VR"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/968370.py
+++ b/gamefixes-steam/968370.py
@@ -2,7 +2,7 @@
 garbled fonts & No cursive font (Segoe Script)
 """
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/976310.py
+++ b/gamefixes-steam/976310.py
@@ -1,6 +1,6 @@
 """Game fix Mortal Kombat 11"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/976730.py
+++ b/gamefixes-steam/976730.py
@@ -1,6 +1,6 @@
 """Game fix Halo:MCC"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/9900.py
+++ b/gamefixes-steam/9900.py
@@ -1,6 +1,6 @@
 """Game fix for Star Trek Online launcher"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/997070.py
+++ b/gamefixes-steam/997070.py
@@ -1,6 +1,6 @@
 """Game fix Marvel's Avengers"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-steam/default.py
+++ b/gamefixes-steam/default.py
@@ -4,7 +4,7 @@ even if no game fix is present. It is run before game fixes are applied.
 """
 
 import sys
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-umu/umu-2016590.py
+++ b/gamefixes-umu/umu-2016590.py
@@ -1,6 +1,6 @@
 """Game fix for Dark and Darker"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-umu/umu-39190.py
+++ b/gamefixes-umu/umu-39190.py
@@ -1,6 +1,6 @@
 """Game fix for Dungeon Siege"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-umu/umu-identityv.py
+++ b/gamefixes-umu/umu-identityv.py
@@ -1,6 +1,6 @@
 """Game fix for Identity V"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-umu/umu-model2.py
+++ b/gamefixes-umu/umu-model2.py
@@ -1,7 +1,6 @@
 """Application fix Model 2 emulator"""
-#
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-umu/umu-silenthill3.py
+++ b/gamefixes-umu/umu-silenthill3.py
@@ -1,6 +1,6 @@
 """Game fix for Silent Hill 3"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-umu/umu-starcitizen.py
+++ b/gamefixes-umu/umu-starcitizen.py
@@ -1,6 +1,6 @@
 """Game fix for Star Citizen"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-umu/umu-zenlesszonezero.py
+++ b/gamefixes-umu/umu-zenlesszonezero.py
@@ -1,6 +1,6 @@
 """Game fix for Zenless Zone Zero"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-umu/winetricks-gui.py
+++ b/gamefixes-umu/winetricks-gui.py
@@ -1,6 +1,6 @@
 """Call Winetricks GUI"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-zoomplatform/umu-240200.py
+++ b/gamefixes-zoomplatform/umu-240200.py
@@ -1,6 +1,6 @@
 """Duke Nukem: Manhattan Project - Enhanced Edition"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/gamefixes-zoomplatform/umu-4bff76f4-566a-4714-b481-95d3343afe22.py
+++ b/gamefixes-zoomplatform/umu-4bff76f4-566a-4714-b481-95d3343afe22.py
@@ -1,6 +1,6 @@
 """Incoming Trilogy"""
 
-from protonfixes import util
+from .. import util
 
 
 def main() -> None:

--- a/protonfixes_test.py
+++ b/protonfixes_test.py
@@ -1,11 +1,13 @@
-import unittest
+import io
 import os
 import tempfile
+import unittest
+import urllib.request
+
 from pathlib import Path
 from unittest.mock import patch, mock_open
-import io
-import urllib.request
-import fix
+
+from . import fix
 
 
 class TestProtonfixes(unittest.TestCase):
@@ -315,7 +317,7 @@ class TestProtonfixes(unittest.TestCase):
 
         with patch('builtins.open', mock_open()) as mocked_open:
             mocked_open.side_effect = FileNotFoundError
-            with patch('fix.log') as mocked_log:  # Mock the logger separately
+            with patch('protonfixes.fix.log') as mocked_log:  # Mock the logger separately
                 func = fix.get_game_name.__wrapped__  # Do not reference the cache
                 result = func()
                 self.assertEqual(result, 'UNKNOWN')
@@ -329,7 +331,7 @@ class TestProtonfixes(unittest.TestCase):
 
         with patch('builtins.open', mock_open()) as mocked_open:
             mocked_open.side_effect = OSError
-            with patch('fix.log') as mocked_log:  # Mock the logger separately
+            with patch('protonfixes.fix.log') as mocked_log:  # Mock the logger separately
                 func = fix.get_game_name.__wrapped__  # Do not reference the cache
                 result = func()
                 self.assertEqual(result, 'UNKNOWN')
@@ -357,7 +359,7 @@ class TestProtonfixes(unittest.TestCase):
 
         with patch('builtins.open', mock_open()) as mocked_open:
             mocked_open.side_effect = UnicodeDecodeError('utf-8', b'', 0, 1, '')
-            with patch('fix.log') as mocked_log:  # Mock the logger separately
+            with patch('protonfixes.fix.log') as mocked_log:  # Mock the logger separately
                 func = fix.get_game_name.__wrapped__  # Do not reference the cache
                 result = func()
                 self.assertEqual(result, 'UNKNOWN')

--- a/util.py
+++ b/util.py
@@ -1,7 +1,6 @@
 """Utilities to make gamefixes easier"""
 
 import configparser
-from io import TextIOWrapper
 import os
 import sys
 import re
@@ -12,16 +11,14 @@ import zipfile
 import subprocess
 import urllib.request
 import functools
+
+from io import TextIOWrapper
 from socket import socket, AF_INET, SOCK_DGRAM
 from typing import Literal, Any, Callable, Union
 from collections.abc import Mapping, Generator
 
-try:
-    from .logger import log
-    from .steamhelper import install_app
-except ImportError:
-    from logger import log
-    from steamhelper import install_app
+from .logger import log
+from .steamhelper import install_app
 
 try:
     import __main__ as protonmain


### PR DESCRIPTION
Cherry-picked and adopted from #152 

The unit tests no longer require imports in a try block.
Also, the game fixes imports have been replaced to be relative, as this is necessary for static type checking.