### PR TITLE
CI: Annotations for shellcheck and ruff + enable pyright (without static type checking)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,11 +33,13 @@ jobs:
 
       # FIXME: problem matcher is currently disabled upstream, using a fork for the moment
       # https://github.com/ludeeus/action-shellcheck/pull/103
+      # FIXME: symlinks don't work upstream
+      # https://github.com/ludeeus/action-shellcheck/pull/104
       - name: Run ShellCheck
-        uses: Root-Core/action-shellcheck@master
+        uses: Root-Core/action-shellcheck@fork
         with:
-          format: gcc # gcc is used for the problem matcher
-          additional_files: winetricks # by default, only files with according extensions are checked
+          ignore_paths: subprojects # prevent ShellCheck from checking unrelated files
+          ignore_symlinks: false # winetricks is symlinked
 
       # Ruff uses ruff.toml for it's configuration
       - name: Lint with Ruff

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,12 @@ jobs:
           pip install trio
           pip install "steam[client]"
 
+      # PyRight, the unit tests, and other scripts import/resolve the "protonfixes" module
+      # We are using the path "umu-protonfixes", which isn't a valid module name and can't be used
+      # However: this simple, hacky symbolic link in the parent folder can fix this inconvenience
+      - name: Fix python module resolution
+        run: ln -rs . ../protonfixes
+
       # FIXME: problem matcher is currently disabled upstream, using a fork for the moment
       # https://github.com/ludeeus/action-shellcheck/pull/103
       # FIXME: symlinks don't work upstream
@@ -53,12 +59,6 @@ jobs:
         run: |
           python3 .github/scripts/check_gamefixes.py
           python3 .github/scripts/check_verbs.py
-
-      # We need a known parent package in the unit tests, so we need to change to the parent dir
-      # As "umu-protonfixes" is not a valid package name, we create a symbolic link to "protonfixes"
-      - name: Fix package resolution
-        run: |
-          ln -s umu-protonfixes ../protonfixes
 
       - name: Validate gamefix imports
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,37 +17,51 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 0
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           # The Steam Runtime platform (sniper) uses Python 3.9
           python-version: "3.9"
-      - name: Install dependencies
+          cache: 'pip' # caching pip dependencies
+
+      - name: Install Python dependencies
         run: |
-          sudo apt-get install shellcheck
-          python3 -m pip install --upgrade pip
-          pip install ruff
           pip install ijson
           pip install trio
           pip install "steam[client]"
-      - name: Lint with Shellcheck
-        run: |
-          shellcheck winetricks
+
+      # FIXME: problem matcher is currently disabled upstream, using a fork for the moment
+      # https://github.com/ludeeus/action-shellcheck/pull/103
+      - name: Run ShellCheck
+        uses: Root-Core/action-shellcheck@master
+        with:
+          format: gcc # gcc is used for the problem matcher
+          additional_files: winetricks # by default, only files with according extensions are checked
+
+      # Ruff uses ruff.toml for it's configuration
       - name: Lint with Ruff
-        run: |
-          ruff check .
+        uses: astral-sh/ruff-action@v1
+
+      # Pyright uses pyproject.toml for it's configuration
+      - name: Static type checking with Pyright
+        uses: jakebailey/pyright-action@v2
+
       - name: Validate gamefix modules
         run: |
           python3 .github/scripts/check_gamefixes.py
           python3 .github/scripts/check_verbs.py
+
       # We need a known parent package in the unit tests, so we need to change to the parent dir
       # As "umu-protonfixes" is not a valid package name, we create a symbolic link to "protonfixes"
       - name: Fix package resolution
         run: |
           ln -s umu-protonfixes ../protonfixes
+
       - name: Validate gamefix imports
         run: |
           python3 .github/scripts/check_imports.py
+
       - name: Test with unittest
         run: |
           cd ..

--- a/fix.py
+++ b/fix.py
@@ -15,7 +15,8 @@ from .logger import log
 try:
     import __main__ as protonmain  # noqa F401
 except ImportError:
-    log.warn('Unable to hook into Proton main script environment')
+    log.crit('Unable to hook into Proton main script environment')
+    exit()
 
 
 @lru_cache

--- a/fix.py
+++ b/fix.py
@@ -12,12 +12,6 @@ from .config import config
 from .checks import run_checks
 from .logger import log
 
-try:
-    import __main__ as protonmain  # noqa F401
-except ImportError:
-    log.crit('Unable to hook into Proton main script environment')
-    exit()
-
 
 @lru_cache
 def get_game_id() -> str:

--- a/protonfixes_test.py
+++ b/protonfixes_test.py
@@ -1,8 +1,6 @@
-import io
 import os
 import tempfile
 import unittest
-import urllib.request
 
 from pathlib import Path
 from unittest.mock import patch, mock_open

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,3 +19,4 @@ exclude = [
 ]
 pythonVersion = "3.9"
 pythonPlatform = "Linux"
+typeCheckingMode = "off"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,21 @@
+[project]
+name = "umu-protonfixes"
+description = "Stop gap solution to fix issues in games that run under Wine."
+keywords = ["proton", "protontricks", "wine", "winetricks", "linux", "gaming"]
+license = {file = "LICENSE"}
+requires-python = "3.9"
+
+
+[project.urls]
+Repository = "https://github.com/Open-Wine-Components/umu-protonfixes.git"
+Issues = "https://github.com/Open-Wine-Components/umu-protonfixes/issues"
+
+
+[tool.pyright]
+exclude = [
+    "**/__pycache__",
+    "subprojects",
+    "verbs"
+]
+pythonVersion = "3.9"
+pythonPlatform = "Linux"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,4 +19,12 @@ exclude = [
 ]
 pythonVersion = "3.9"
 pythonPlatform = "Linux"
+
 typeCheckingMode = "off"
+reportMissingImports = "error"
+reportMissingModuleSource = "error"
+reportUnusedImport = "error"
+reportDuplicateImport = "error"
+reportWildcardImportFromLibrary = "error"
+reportPrivateImportUsage = "error"
+reportShadowedImports = "error"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ exclude = [
     "subprojects",
     "verbs"
 ]
+extraPaths = [ ".." ] # Fix "protonfixes" module resolution
 pythonVersion = "3.9"
 pythonPlatform = "Linux"
 

--- a/util.py
+++ b/util.py
@@ -24,7 +24,8 @@ from .steamhelper import install_app
 try:
     import __main__ as protonmain
 except ImportError:
-    log.warn('Unable to hook into Proton main script environment')
+    log.crit('Unable to hook into Proton main script environment')
+    exit()
 
 
 def which(appname: str) -> Union[str, None]:


### PR DESCRIPTION
Cherry-picked and adopted from #152

As discussed in #204 Pyright is able to check the imports, [without checking types](https://github.com/microsoft/pyright/blob/main/docs/configuration.md#type-check-diagnostics-settings). I'm not sure what else is tested, but imports are.