### PR TITLE
Add launcher skip for X-Blades

### DIFF
--- a/gamefixes-steam/7510.py
+++ b/gamefixes-steam/7510.py
@@ -1,0 +1,8 @@
+"""X-Blades"""
+
+from protonfixes import util
+
+
+def main() -> None:
+    """The launcher won't start the game, so it needs to be skipped for the game to run."""
+    util.replace_command('launcher\\.exe$', 'xblades.exe')


### PR DESCRIPTION
The launcher fails to start the game, so this workaround skips it and launches the actual game's executable instead, which is apparently known to work. This will not do any actual renaming, it instead replaces a command-line argument so it launches the actual game directly.

https://github.com/ValveSoftware/Proton/issues/8383#issue-2779089880