### PR TITLE
Add fix for Marvel Rivals

### DIFF
--- a/gamefixes-steam/2767030.py
+++ b/gamefixes-steam/2767030.py
@@ -1,0 +1,8 @@
+"""Game fix for Marvel Rivals"""
+
+from protonfixes import util
+
+
+def main() -> None:
+    """Game needs SteamDeck=1 to start since season 1"""
+    util.set_environment('SteamDeck', '1')


### PR DESCRIPTION
Since season 1 (launched hours ago) without the SteamDeck=1 env var the game fails to start properly with UE5 errors
Adding it seems to fix it


https://www.reddit.com/r/linux_gaming/comments/1hy320b/seems_like_marvel_rivals_no_longer_runs_on_linux/