### PR TITLE
Remove fix for Marvel Rivals

### DIFF
--- a/gamefixes-steam/2767030.py
+++ b/gamefixes-steam/2767030.py
@@ -1,8 +1,0 @@
-"""Game fix for Marvel Rivals"""
-
-from protonfixes import util
-
-
-def main() -> None:
-    """Game needs SteamDeck=1 to start since season 1"""
-    util.set_environment('SteamDeck', '1')


### PR DESCRIPTION
The crash when running without `SteamDeck=1` have been fixed in Proton Bleeding Edge
https://github.com/ValveSoftware/wine/compare/31cf4f9...46b9e1d

https://github.com/ValveSoftware/Proton/issues/8300