### PR TITLE
Add fix for Middle-earth: Shadow of War (GOG)

### DIFF
--- a/gamefixes-gog/umu-356190.py
+++ b/gamefixes-gog/umu-356190.py
@@ -1,0 +1,1 @@
+../gamefixes-steam/356190.py


### PR DESCRIPTION
This game is already in the database but the fix was only applied to the Steam version. Added it here for the GOG version as well.

Proton issue: https://github.com/ValveSoftware/Proton/issues/135#issuecomment-1661207438