### PR TITLE
Add fix for Marvel Rivals

### DIFF
--- a/gamefixes-steam/2767030.py
+++ b/gamefixes-steam/2767030.py
@@ -1,0 +1,8 @@
+"""Game fix for Marvel Rivals"""
+
+from protonfixes import util
+
+
+def main() -> None:
+    """Game needs SteamDeck=1 not to crash on start-up"""
+    util.set_environment('SteamDeck', '1')


### PR DESCRIPTION
Needs `SteamDeck=1` to avoiding crashing on start-up.

See also: https://www.protondb.com/app/2767030.