### PR TITLE
Update Middle-earth: Shadow of War (GOG/Steam)

### DIFF
--- a/gamefixes-gog/umu-356190.py
+++ b/gamefixes-gog/umu-356190.py
@@ -1,1 +1,7 @@
-../gamefixes-steam/356190.py
+"""Game fix for Middle-earth: Shadow of War"""
+
+from protonfixes import util
+
+def main() -> None:
+    # Requires vcrun2022 to launch
+    util.protontricks('vcrun2022')

--- a/gamefixes-steam/356190.py
+++ b/gamefixes-steam/356190.py
@@ -4,5 +4,5 @@ from protonfixes import util
 
 
 def main() -> None:
-    # Requires vcrun2019 to launch
-    util.protontricks('vcrun2019')
+    # Requires vcrun2022 to launch
+    util.protontricks('vcrun2022')

--- a/gamefixes-steam/356190.py
+++ b/gamefixes-steam/356190.py
@@ -1,8 +1,0 @@
-"""Game fix Shadow of War"""
-
-from protonfixes import util
-
-
-def main() -> None:
-    # Requires vcrun2022 to launch
-    util.protontricks('vcrun2022')


### PR DESCRIPTION
Updated to vcrun2022.

I seem to be getting the following error when using vcrun2019:

```
Executing cd /home/deck/.cache/winetricks/vcrun2019
Executing /home/deck/.config/heroic/tools/proton/Proton-GE-Proton9-23/files/bin/wine vc_redist.x86.exe /q
fsync: up and running.
------------------------------------------------------
warning: Note: command /home/deck/.config/heroic/tools/proton/Proton-GE-Proton9-23/files/bin/wine vc_redist.x86.exe /q returned status 102. Aborting.
------------------------------------------------------
[33mProtonFixes[36985] WARN: Winetricks failed running verb "vcrun2019" with status 1.[0m
Proton: /home/deck/Games/Heroic/Shadow of War/x64/ShadowOfWar.exe
Proton: Executable a unix path, launching with /unix option.
fsync: up and running.
Command exited with status: 0
Launch command: ['/home/deck/.config/heroic/tools/runtimes/umu/umu_run.py', '/home/deck/Games/Heroic/Shadow of War/x64/ShadowOfWar.exe']
All processes exited
============= End of log =============
```

No issues when using vcrun2022. Not sure if this is a separate issue altogether though.