### PR TITLE
Install vcrun2022 for all Epic titles by default

### DIFF
--- a/gamefixes-amazon/umu-976590.py
+++ b/gamefixes-amazon/umu-976590.py
@@ -1,1 +1,0 @@
-../gamefixes-egs/umu-976590.py

--- a/gamefixes-egs/default.py
+++ b/gamefixes-egs/default.py
@@ -1,6 +1,5 @@
+"""Install vcrun2022 for all EGS games"""
 from protonfixes import util
-
-# Install vcrun2022 for all EGS games
 
 def main() -> None:
     util.protontricks('vcrun2022')

--- a/gamefixes-egs/default.py
+++ b/gamefixes-egs/default.py
@@ -1,8 +1,6 @@
-"""Game fix for Bus Simulator 21 Next Stop"""
-
 from protonfixes import util
 
+# Install vcrun2022 for all EGS games
 
 def main() -> None:
-    # Requires vcrun2022 to launch
     util.protontricks('vcrun2022')

--- a/gamefixes-egs/umu-1151640.py
+++ b/gamefixes-egs/umu-1151640.py
@@ -1,1 +1,0 @@
-../gamefixes-steam/1151640.py

--- a/gamefixes-egs/umu-1248080.py
+++ b/gamefixes-egs/umu-1248080.py
@@ -1,8 +1,0 @@
-"""Game fix for CYGNI: All Guns Blazing"""
-
-from protonfixes import util
-
-
-def main() -> None:
-    # EGS only: This fixes the startup process.
-    util.append_argument('-epicdeploymentid=78a046d4ac1b42d7aaba9fe80f88a5d8')

--- a/gamefixes-egs/umu-1361510.py
+++ b/gamefixes-egs/umu-1361510.py
@@ -1,1 +1,0 @@
-../gamefixes-steam/1361510.py

--- a/gamefixes-egs/umu-1370140.py
+++ b/gamefixes-egs/umu-1370140.py
@@ -1,8 +1,0 @@
-"""Game fix Kao the Kangaroo (2022)"""
-
-from protonfixes import util
-
-
-def main() -> None:
-    # Requires vcrun2022 to launch
-    util.protontricks('vcrun2022')

--- a/gamefixes-egs/umu-1521160.py
+++ b/gamefixes-egs/umu-1521160.py
@@ -1,8 +1,0 @@
-"""Game fix for Are You Smarter Than A 5th Grader"""
-
-from protonfixes import util
-
-
-def main() -> None:
-    # Requires vcrun2022 to launch
-    util.protontricks('vcrun2022')

--- a/gamefixes-egs/umu-1544020.py
+++ b/gamefixes-egs/umu-1544020.py
@@ -1,1 +1,0 @@
-../gamefixes-steam/1544020.py

--- a/gamefixes-egs/umu-2138710.py
+++ b/gamefixes-egs/umu-2138710.py
@@ -1,8 +1,0 @@
-"""Game fix for Sifu"""
-
-from protonfixes import util
-
-
-def main() -> None:
-    # Requires vcrun2022 to launch
-    util.protontricks('vcrun2022')

--- a/gamefixes-egs/umu-2144740.py
+++ b/gamefixes-egs/umu-2144740.py
@@ -1,8 +1,0 @@
-"""Game fix for Ghost Runner 2"""
-
-from protonfixes import util
-
-
-def main() -> None:
-    # Requires vcrun2022 to launch
-    util.protontricks('vcrun2022')

--- a/gamefixes-egs/umu-2229940.py
+++ b/gamefixes-egs/umu-2229940.py
@@ -1,8 +1,0 @@
-"""Game fix for [REDACTED]"""
-
-from protonfixes import util
-
-
-def main() -> None:
-    # Requires vcrun2022 to launch
-    util.protontricks('vcrun2022')

--- a/gamefixes-egs/umu-517710.py
+++ b/gamefixes-egs/umu-517710.py
@@ -1,8 +1,0 @@
-"""Game fix Redout: Enhanced Edition"""
-
-from protonfixes import util
-
-
-def main() -> None:
-    # Requires vcrun2019 to launch
-    util.protontricks('vcrun2019')

--- a/gamefixes-egs/umu-990080.py
+++ b/gamefixes-egs/umu-990080.py
@@ -1,8 +1,0 @@
-"""Game fix Hogwarts Legacy"""
-
-from protonfixes import util
-
-
-def main() -> None:
-    # Requires vcrun2019 to launch
-    util.protontricks('vcrun2019')

--- a/gamefixes-steam/397540.py
+++ b/gamefixes-steam/397540.py
@@ -4,7 +4,6 @@ from protonfixes import util
 
 
 def main() -> None:
-    """Borderlands 3 vcrun2019 fix"""
+    """Borderlands 3"""
     # Fixes the startup process.
-    util.protontricks('vcrun2019')
     util.protontricks('d3dcompiler_47')


### PR DESCRIPTION
This is the only verb that's not provided with games usually. As games assume EGS will install that. This is not the case for tools based on legendary, so this is why we had vcrun2022 for every problematic title. I believe we should add it for every possible game, there are no downsides to this.

This PR also removes some obsolete fixes like 
- `CYGNI: All Guns Blazing` - the parameter is handled by legendary itself now
- `Borderlands 3`'s vcrun2019 install - the verb will be handled by EGS vcrun2022 and Steam version provides necessary dependencies via its install scripts 