### PR TITLE
Add functionality to symlink save data from another game's prefix, a few games would benefit from this

### DIFF
--- a/gamefixes-steam/2561580.py
+++ b/gamefixes-steam/2561580.py
@@ -1,7 +1,5 @@
 """Horizon Zero Dawn Remastered"""
 
-from sys import argv
-from os import environ
 from protonfixes import util
 
 

--- a/gamefixes-steam/2561580.py
+++ b/gamefixes-steam/2561580.py
@@ -6,8 +6,5 @@ from protonfixes import util
 
 
 def main() -> None:
-    """Won't connect to internet to login to PSN without using `-showlinkingqr` or `SteamDeck=1` options."""
-    if environ.get('SteamDeck', '0') == '0' and '-showlinkingqr' not in argv:
-        util.append_argument('-showlinkingqr')
-    # this allows the game to detect saves from the original Complete Edition
+    """Game allows playing saves from the original Complete Edition, but by default it can't find them."""
     util.import_saves_folder(1151640, 'My Documents/Horizon Zero Dawn')

--- a/gamefixes-steam/2561580.py
+++ b/gamefixes-steam/2561580.py
@@ -1,4 +1,4 @@
-"""Game fix for Horizon Zero Dawn Remastered"""
+"""Horizon Zero Dawn Remastered"""
 
 from sys import argv
 from os import environ
@@ -6,6 +6,8 @@ from protonfixes import util
 
 
 def main() -> None:
-    """Won't connect to internet without using `-showlinkingqr` or `SteamDeck=1` options."""
+    """Won't connect to internet to login to PSN without using `-showlinkingqr` or `SteamDeck=1` options."""
     if environ.get('SteamDeck', '0') == '0' and '-showlinkingqr' not in argv:
         util.append_argument('-showlinkingqr')
+    # this allows the game to detect saves from the original Complete Edition
+    util.import_saves_folder(1151640, 'My Documents/Horizon Zero Dawn')

--- a/gamefixes-steam/2909400.py
+++ b/gamefixes-steam/2909400.py
@@ -1,0 +1,8 @@
+"""Final Fantasy VII Rebirth"""
+
+from protonfixes import util
+
+
+def main() -> None:
+    """Grants bonus items to players with save data for Final Fantasy VII Remake Intergrade"""
+    util.import_saves_folder(1462040, 'Documents/My Games/FINAL FANTASY VII REMAKE')

--- a/util.py
+++ b/util.py
@@ -1005,10 +1005,10 @@ def import_saves_folder(from_appid: int, relative_path: str) -> bool:
     for i in paths:
         if Path(f'{i}/steamapps/compatdata/{from_appid}').exists():
             # The user's folder in the prefix location for from_appid
-            prefix = f'{i}/steamapps/compatdata/{from_appid}/pfx/drive_c/users/steamuser/{relative_location}'
+            prefix = f'{i}/steamapps/compatdata/{from_appid}/pfx/drive_c/users/steamuser/{relative_path}'
             if not Path(prefix).exists():
                 # Better to just abort than create a broken symlink
-                log.info(f'Skipping save data folder import due to location `{relative_location}` not existing in the prefix for {from_appid}.')
+                log.info(f'Skipping save data folder import due to location `{relative_path}` not existing in the prefix for {from_appid}.')
                 return False
             break
     # If one wasn't found, do nothing.

--- a/util.py
+++ b/util.py
@@ -971,43 +971,66 @@ def set_game_drive(enabled: bool) -> None:
     else:
         protonmain.g_session.compat_config.discard('gamedrive')
 
-def import_saves_folder(from_appid: int, relative_path: str) -> None:
-    """Creates a symlink to a folder in another game's prefix.
-    You can use this for games that have functionality that depends on having save data for another game, which does NOT store its save data in its steamapps/common folder.
+def import_saves_folder(from_appid: int, relative_path: str) -> bool:
+    """Creates a symlink in the prefix for the game you're trying to play, to a folder from another game's prefix (it needs to be in a Steam library folder).
+    You can use this for games that have functionality that depends on having save data for another game or demo,
+        which does NOT store its save data in its steamapps/common folder.
     This will only work for Steam games.
-    
+
     from_appid: Steam App ID of the game you're trying to get the saves folder from
-    relative_path: Path to reach the target folder that has the save data, starting from .../pfx/drive_c/users/steamuser
+        You can find this number in the URL for the game's store page, or through looking up the game in SteamDB.
+    relative_path: Path to reach the target folder that has the save data, starting from the .../pfx/drive_c/users/steamuser folder
+        For example for the "My Documents/(Game name)" folder, just use "My Documents/(Game name)".
     """
     from pathlib import Path
     paths = []
+    # Valid Steam app IDs always end with a zero.
+    if from_appid <= 0 or from_appid % 10 != 0:
+        log.warn(f'Invalid ID used for import_saves_folder ({from_appid}).')
+        return False
     # Locate the prefix for from_appid
     # The location of Steam's main folder can be found in the STEAM_BASE_FOLDER environment variable
-    # The libraryfolders.vdf file contains the paths for all your Steam library folders, including those on external drives or SD cards.
-    with open(f'{os.environ["STEAM_BASE_FOLDER"]}/steamapps/libraryfolders.vdf') as f:
-        for i in f.readlines():
-            if '"path"' in i:
-                paths.append(i[11:-1])
+    # The libraryfolders.vdf file contains the paths for all your Steam library folders that are known to the Steam client, including those on external drives or SD cards.
+    try:
+        with open(f'{os.environ["STEAM_BASE_FOLDER"]}/steamapps/libraryfolders.vdf') as f:
+            for i in f.readlines():
+                # Looking for lines of the format 
+                # \t\t"path"\t\t"(the path)"
+                if '"path"' in i:
+                    paths.append(i[11:-1])
+    except FileNotFoundError:
+        log.info("Could not find Steam's libraryfolders.vdf file.")
+        return False
     # Find which of the library folders the prefix is in
     for i in paths:
         if Path(f'{i}/steamapps/compatdata/{from_appid}').exists():
-            # The prefix location for from_appid
-            prefix = f'{i}/steamapps/compatdata/{from_appid}/pfx/drive_c'
+            # The user's folder in the prefix location for from_appid
+            prefix = f'{i}/steamapps/compatdata/{from_appid}/pfx/drive_c/users/steamuser/{relative_location}'
+            if not Path(prefix).exists():
+                # Better to just abort than create a broken symlink
+                log.info(f'Skipping save data folder import due to location `{relative_location}` not existing in the prefix for {from_appid}.')
+                return False
             break
-    # If it wasn't found, do nothing.
+    # If one wasn't found, do nothing.
     else:
-        return
+        log.info(f'Skipping save data folder import, due to not finding a prefix for game {from_appid} to get the folder from.')
+        return False
     # Create the symlink
-    # STEAM_COMPAT_DATA_PATH contains the location of the prefix for the game you're trying to play.
-    goal = Path(f'{os.environ["STEAM_COMPAT_DATA_PATH"]}/pfx/drive_c/users/steamuser/{relative_path}')
+    goal = Path(f'{protonprefix()}/drive_c/users/steamuser/{relative_path}')
     # The goal is where we intend to create the symlink
     if not goal.exists():
         # Create the necessary parent folders if needed
         goal.parent.mkdir(parents=True, exist_ok=True)
-        goal.symlink_to(f'{prefix}/users/steamuser/{relative_path}', True)
+        goal.symlink_to(prefix, True)
+        log.info(f'Created a symlink at `{goal}` to go to `{prefix}`')
+        return True
     elif not goal.is_symlink():
-        return
+        return False
     elif not goal.readlink().exists():
-        # In the case the prefix was moved to another drive, remove and re-create the symlink to point to the correct location
+        # In the case the prefix for the other game was moved to another location, remove and re-create the symlink to point to the correct location
         goal.unlink()
-        goal.symlink_to(f'{prefix}/users/steamuser/{relative_path}', True)
+        goal.symlink_to(prefix, True)
+        log.info(f'Replaced symlink at `{goal}` to go to `{prefix}`')
+        return True
+    else:
+        return False


### PR DESCRIPTION
Some games have functionality that is dependent on having save data for another game, which works fine on Windows, but needs workarounds on Proton due to how it handles stuff that is stored in the user folder rather than the game's own `steamapps/common` folder (usually under Documents or My Games). This leads to the game not detecting the save data for the other game despite it being there, because it's in a different prefix.

This pull request adds a new function for `util` that can be used to automate a symlinking workaround to accomplish this.

This will only work if you have the other game installed from Steam.

# How this works

1. Reads Steam's `steamapps/libraryfolders.vdf` file to find locations of known library folders.
2. Iterates through each of the library folders to determine if it can find a `compatdata/(APPID)` folder in it.
3. If it finds one, it will create a symlink in the current game's prefix to point to the location in the found prefix, at the location the game expects to find the save data folder for the other game.

# Games impacted
- **Final Fantasy VII Rebirth**: Has bonus content (or something, I don't know what) for players with save data from FF7 Remake Intergrade, which would be found in the documents folder.
- **Horizon Zero Dawn Remastered**: Allows playing saves from the original Complete Edition, which are stored in the documents folder.
- **Metaphor ReFantazio**: Allows continuing from saves made in its demo, which uses a different ID and thus a different prefix.
- Utawarerumono (**Utawarerumono: Prelude to the Fallen** and **Utawarerumono: Mask of Truth**)

## How to use the Function
```py
def import_saves_folder(from_appid: int, relative_path: str)
```
Parameters:
- `from_appid`: The Steam app id for the game whose save data is desired in the prefix for the game you're trying to play.
- `relative_path`: The location in the `drive_c/users/steamuser` folder where the game expects the save data for the other game to be. You can find this by looking up the game on [PC Gaming Wiki](https://pcgamingwiki.com).
This function will have to be used in the fix scripts for each of the games that need it.