### PR TITLE
Rename logging test file

### DIFF
--- a/logger.py
+++ b/logger.py
@@ -30,7 +30,7 @@ class Log:
         fulltext = color + pfx + str(msg) + reset + os.linesep
         sys.stderr.write(fulltext)
         sys.stderr.flush()
-        with open('/tmp/test', 'a', 1, encoding='utf-8') as testfile:
+        with open('/tmp/protonfixes_test.log', 'a', 1, encoding='utf-8') as testfile:
             testfile.write(logtext)
 
     def info(self, msg: str) -> None:


### PR DESCRIPTION
Make it more obvious that it is from Protonfixes. Same file name could also be used by other applications.