### PR TITLE
God of War Ragnarok should no longer need SteamDeck=1, game was updated to remove PSN requirement

### DIFF
--- a/gamefixes-steam/2322010.py
+++ b/gamefixes-steam/2322010.py
@@ -1,9 +1,0 @@
-"""Game fix for God of War: Ragnarok
-Will not launch without SteamDeck=1
-"""
-
-from protonfixes import util
-
-
-def main() -> None:
-    util.set_environment('SteamDeck', '1')


### PR DESCRIPTION
Game was updated to remove the PSN login requirement, which the SteamDeck=1 workaround was needed for, so it should no longer be needed to start the game.

https://store.steampowered.com/news/app/2322010/view/534340870063784017?l=english

> Signing into the PlayStation Network will now be optional on God of War Ragnarök PC.