### PR TITLE
Add fix for Angelic Chaos: RE-BOOT!

### DIFF
--- a/gamefixes-umu/umu-tenshisz.py
+++ b/gamefixes-umu/umu-tenshisz.py
@@ -1,0 +1,7 @@
+"""Game fix for Angelic Chaos: RE-BOOT!"""
+
+from protonfixes import util
+
+
+def main() -> None:
+    util.disable_protonmediaconverter()


### PR DESCRIPTION
Closes https://github.com/Open-Wine-Components/umu-protonfixes/issues/220

Like other Yuzusoft titles (e.g., Senren Banka), it currently requires some fixing to have in-game media playback work by either disabling the Proton media converter or installing wmp11, qasf, and quartz.
