### PR TITLE
Add CPU limit for Hard Truck Apocalypse: Rise of Clans

### DIFF
--- a/gamefixes-steam/286810.py
+++ b/gamefixes-steam/286810.py
@@ -1,0 +1,8 @@
+"""Hard Truck Apocalypse: Rise of Clans"""
+
+from protonfixes import util
+
+
+def main() -> None:
+    """Won't start at 32 or more cores."""
+    util.set_cpu_topology_limit(31)


### PR DESCRIPTION
Won't start at 32 or more cores.

https://github.com/ValveSoftware/Proton/issues/5927#issuecomment-2644174115