### PR TITLE
Update `import_saves_folder` to better accomodate for transfering saves from demos that save in the same location as the full game

### DIFF
--- a/util.py
+++ b/util.py
@@ -971,6 +971,7 @@ def set_game_drive(enabled: bool) -> None:
     else:
         protonmain.g_session.compat_config.discard('gamedrive')
 
+
 def import_saves_folder(from_appid: int, relative_path: str, is_demo: bool = False) -> bool:
     """Creates a symlink in the prefix for the game you're trying to play, to a folder from another game's prefix (it needs to be in a Steam library folder).
 
@@ -1057,3 +1058,15 @@ def import_saves_folder(from_appid: int, relative_path: str, is_demo: bool = Fal
         return True
     else:
         return False
+
+
+def get_steam_account_id() -> str:
+    """Returns your 17-digit Steam account ID"""
+    # The loginusers.vdf file contains information about accounts known to the Steam client, and contains their 17-digit IDs
+    with open(f'{os.environ["STEAM_BASE_FOLDER"]}/config/loginusers.vdf') as f:
+        lastFoundId = None
+        for i in f.readlines():
+            if len(i) > 1 and i[2:-1].isdigit():
+                lastFoundId = i[2:-1]
+            elif i == f'\t\t"AccountName"\t\t"{os.environ["SteamUser"]}"':
+                return lastFoundId


### PR DESCRIPTION
This adds an additional parameter to `import_saves_folder` to allow the function to copy files from the other prefix's folder instead of symlinking the whole folder. This is good for demos that save to the same location as the full game, especially if the full game had already made that folder. This also means that save files from the demo won't be deleted if you delete the demo's prefix.

Additionally, the save locations for some games need the user's 17-digit Steam account ID, which the Steam client doesn't offer as an environment variable. This also adds a function to make that easier through reading Steam's `loginusers.vdf` file.

https://github.com/Open-Wine-Components/umu-protonfixes/pull/217#issuecomment-2659717107
> My interpretation of the added code is that the whole folder referenced in the script is symlinked into the current game, but this wouldn't work out very well when the folder is the same such as in the cases of Metaphor and Octopath Traveler 2, especially if the game had already created the save folder and stored some data into it already.