### PR TITLE
Add save detection fix for Utawarerumono: Mask of Truth

### DIFF
--- a/gamefixes-steam/1151440.py
+++ b/gamefixes-steam/1151440.py
@@ -1,0 +1,7 @@
+"""Utawarerumono: Mask of Truth"""
+
+from protonfixes import util
+
+def main() -> None:
+    """Can't find saves for Mask of Deception."""
+    util.import_saves_folder(1149550, 'Documents/AQUAPLUS/Utawarerumono Mask of Deception/Save')


### PR DESCRIPTION
Game is having trouble finding saves for Mask of Deception.

https://www.protondb.com/app/1151440#wd532Y9jpk