### PR TITLE
Handle PermissionError in check_internet

### DIFF
--- a/util.py
+++ b/util.py
@@ -222,7 +222,7 @@ def check_internet() -> bool:
             sock.settimeout(5)
             sock.connect(('1.1.1.1', 53))
         return True
-    except (TimeoutError, OSError):
+    except (TimeoutError, OSError, PermissionError):
         return False
 
 


### PR DESCRIPTION
Updated the `check_internet` function to account for `PermissionError` exception that may occur when the firewall is set to block the connection to 1.1.1.1.