### PR TITLE
Fix Dependabot update error

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,6 @@ updates:
       interval: "weekly"
 
   - package-ecosystem: "gitsubmodule"
-    directory: "subprojects"
+    directory: "/"
     schedule:
       interval: "daily"


### PR DESCRIPTION
Fixes https://github.com/Open-Wine-Components/umu-protonfixes/actions/runs/13444180896

Dependabot looks for the .gitsubmodule file which isn't within the subprojects subdirectory.
