### PR TITLE
Fix account ID determination to allow proper importing of demo save files

### DIFF
--- a/gamefixes-steam/1971650.py
+++ b/gamefixes-steam/1971650.py
@@ -1,0 +1,9 @@
+"""Octopath Traveler 2"""
+
+from protonfixes import util
+
+
+def main() -> None:
+    """Imports demo saves into the full game's prefix"""
+
+    util.import_saves_folder(2203230, f'Documents/My Games/Octopath_Traveler2/Steam/{util.get_steam_account_id()}/SaveGames',True)

--- a/util.py
+++ b/util.py
@@ -1007,7 +1007,7 @@ def import_saves_folder(
                 # Looking for lines of the format
                 # \t\t"path"\t\t"(the path)"
                 if '"path"' in i:
-                    paths.append(i[11:-1])
+                    paths.append(i[11:-2])
     except FileNotFoundError:
         log.info("Could not find Steam's libraryfolders.vdf file.")
         return False
@@ -1075,9 +1075,9 @@ def get_steam_account_id() -> str:
     """Returns your 17-digit Steam account ID"""
     # The loginusers.vdf file contains information about accounts known to the Steam client, and contains their 17-digit IDs
     with open(f'{os.environ["STEAM_BASE_FOLDER"]}/config/loginusers.vdf') as f:
-        lastFoundId = None
+        lastFoundId = "None"
         for i in f.readlines():
-            if len(i) > 1 and i[2:-1].isdigit():
-                lastFoundId = i[2:-1]
-            elif i == f'\t\t"AccountName"\t\t"{os.environ["SteamUser"]}"':
+            if len(i) > 1 and i[2:-2].isdigit():
+                lastFoundId = i[2:-2]
+            elif i == (f'\t\t"AccountName"\t\t"{os.environ["SteamUser"]}"\n'):
                 return lastFoundId


### PR DESCRIPTION
This is a follow up to #217 and #227.

There were small errors in how paths and account IDs were determined because not enough characters were edited out.

In `import_saves_folder`, `for i in paths` would resolve to `/path/to/somewhere"` with the extra `"` at the end.

In `get_steam_account_id`, the search for `"AccountName"` would be looking for a full complete string but was missing the `\n` at the end.

Log excerpt:

```
ProtonFixes[1189702] INFO: Using global defaults for "OCTOPATH TRAVELER II" (1971650)
ProtonFixes[1189702] INFO: Using global protonfix for "OCTOPATH TRAVELER II" (1971650)
ProtonFixes[1189702] INFO: Copied file from `/var/home/outphase/.local/share/Steam/steamapps/compatdata/2203230/pfx/drive_c/users/steamuser/Documents/My Games/Octopath_Traveler2/Steam/76561197970004159/SaveGames/SystemData_Trial.sav` to `/var/home/outphase/.local/share/Steam/steamapps/compatdata/1971650/pfx/drive_c/users/steamuser/Documents/My Games/Octopath_Traveler2/Steam/76561197970004159/SaveGames/SystemData_Trial.sav`
ProtonFixes[1189702] INFO: Copied file from `/var/home/outphase/.local/share/Steam/steamapps/compatdata/2203230/pfx/drive_c/users/steamuser/Documents/My Games/Octopath_Traveler2/Steam/76561197970004159/SaveGames/SaveData0_Trial.sav` to `/var/home/outphase/.local/share/Steam/steamapps/compatdata/1971650/pfx/drive_c/users/steamuser/Documents/My Games/Octopath_Traveler2/Steam/76561197970004159/SaveGames/SaveData0_Trial.sav`
ProtonFixes[1189702] INFO: Copied file from `/var/home/outphase/.local/share/Steam/steamapps/compatdata/2203230/pfx/drive_c/users/steamuser/Documents/My Games/Octopath_Traveler2/Steam/76561197970004159/SaveGames/SaveData1_Trial.sav` to `/var/home/outphase/.local/share/Steam/steamapps/compatdata/1971650/pfx/drive_c/users/steamuser/Documents/My Games/Octopath_Traveler2/Steam/76561197970004159/SaveGames/SaveData1_Trial.sav`
```