### PR TITLE
Enable game drive for Supermarket Together

### DIFF
--- a/gamefixes-steam/2709570.py
+++ b/gamefixes-steam/2709570.py
@@ -1,0 +1,8 @@
+"""Supermarket Together"""
+
+from protonfixes import util
+
+
+def main() -> None:
+    """Fixes an issue with the Cool Pack DLC."""
+    util.set_game_drive(True)


### PR DESCRIPTION
This fixes an issue with the Cool Pack DLC, as described in ValveSoftware/Proton#8470.