### PR TITLE
Add save import fix for Cardfight Vanguard Dear Days 2

### DIFF
--- a/gamefixes-steam/2457540.py
+++ b/gamefixes-steam/2457540.py
@@ -1,0 +1,8 @@
+"""Cardfight!! Vanguard Dear Days 2"""
+
+from protonfixes import util
+
+
+def main() -> None:
+    """imports player cards from  Cardfight!! Vanguard Dear Days. Yes that save path is indeed VG2 no idea why"""
+    util.import_saves_folder(1881420,'Saved Games/VG2/SAVELOAD')


### PR DESCRIPTION
This proton fix allows  for Cardfight Vanguard Dear Days 2 to import a players  card collection   from  the previous  Dear Days game.  Please Kindly ignore the  Mangled commit message I was working in the  dark