### PR TITLE
Yuzusoft Game fixes (Yet Again)

### DIFF
--- a/gamefixes-steam/1144400.py
+++ b/gamefixes-steam/1144400.py
@@ -1,4 +1,4 @@
-""" Game fix for Sanoba Witch FHD Edition
+""" Game fix for Senren＊Banka
 """
 from protonfixes import util
 

--- a/gamefixes-steam/1277930.py
+++ b/gamefixes-steam/1277930.py
@@ -1,8 +1,12 @@
-"""Game fix for Riddle Joker"""
-
+""" Game fix for Riddle Joker
+"""
 from protonfixes import util
 
+def main():
+    """Install quartz, wmp11, qasf
 
-def main() -> None:
-    """Fixes in-game video playback for the intro and ending."""
-    util.disable_protonmediaconverter()
+    Fixes in-game video playback for the intro and ending.
+    """
+    util.protontricks('quartz')
+    util.protontricks('wmp11')
+    util.protontricks('qasf')

--- a/gamefixes-steam/1829980.py
+++ b/gamefixes-steam/1829980.py
@@ -1,8 +1,12 @@
-"""Game fix for Café Stella and the Reaper's Butterflies"""
-
+""" Game fix for Cafe Stella
+"""
 from protonfixes import util
 
+def main():
+    """Install quartz, wmp11, qasf
 
-def main() -> None:
-    """Fixes in-game video playback for the intro and ending."""
-    util.disable_protonmediaconverter()
+    Fixes in-game video playback for the intro and ending.
+    """
+    util.protontricks('quartz')
+    util.protontricks('wmp11')
+    util.protontricks('qasf')

--- a/gamefixes-steam/888790.py
+++ b/gamefixes-steam/888790.py
@@ -1,11 +1,12 @@
-"""Game fix for Sabbat of the Witch"""
-
+""" Game fix for Sabbat of the Witch
+"""
 from protonfixes import util
 
+def main():
+    """Install quartz, wmp11, qasf
 
-def main() -> None:
-    """Fixes in-game video playback for the intro and ending."""
-    util.disable_protonmediaconverter()
-    # Changes the video renderer to 'overlay' to prevent random crashes
-    # See https://github.com/Open-Wine-Components/umu-protonfixes/pull/115#issuecomment-2319197337
-    util.append_argument('-vomstyle=overlay')
+    Fixes in-game video playback for the intro and ending.
+    """
+    util.protontricks('quartz')
+    util.protontricks('wmp11')
+    util.protontricks('qasf')


### PR DESCRIPTION
Fixes video playback issues with Yuzusoft titles
Fixes Riddle Joker, Senren Banka, Cafe Stella, Sabbat of the Witch and Sanoba Witch FHD Edition

Versions after 9-12 broke the current fix, the one that disables the protonmediaconverter. Which makes it where the game will crash upon trying to play a video

This fix works without issue. No audio, graphical or crashing problems
i got tired of constantly having to manually install it myself with every new release