### PR TITLE
Remove no longer needed Supermarket Together fix, addressed upstream

### DIFF
--- a/gamefixes-steam/2709570.py
+++ b/gamefixes-steam/2709570.py
@@ -1,8 +1,0 @@
-"""Supermarket Together"""
-
-from protonfixes import util
-
-
-def main() -> None:
-    """Fixes an issue with the Cool Pack DLC."""
-    util.set_game_drive(True)


### PR DESCRIPTION
https://github.com/ValveSoftware/Proton/commit/9fdc470c3ae78e5d79f4eb5dcc200986db4eae50