### PR TITLE
Add fix for Deus Ex: Invisible War extremely loud audio glitches

### DIFF
--- a/gamefixes-steam/6920.py
+++ b/gamefixes-steam/6920.py
@@ -1,0 +1,9 @@
+"""Deus Ex: Invisible War"""
+
+from protonfixes import util
+
+
+def main() -> None:
+    # Fix for extremely loud audio glitches when using Spy Drones
+    util.protontricks('dsound')
+    


### PR DESCRIPTION
This fixes the extremely loud audio glitches that happen at various points in the game, most notably during the hangar section and when using Spy Drones.