### PR TITLE
Add fix for PowerWash Adventure

### DIFF
--- a/gamefixes-steam/2699660.py
+++ b/gamefixes-steam/2699660.py
@@ -1,0 +1,8 @@
+"""PowerWash Adventure"""
+
+from protonfixes import util
+
+
+def main() -> None:
+    """Needs vcrun2019 to fix 'Visual C++ Runtime' required error"""
+    util.protontricks('vcrun2022')


### PR DESCRIPTION
PowerWash Adventure requires `vcrun2022` in order to fix a pop-up complaining that "Visual C++ Runtime" is required. I found that `vcrun2022` fixed this, and that `vcrun2019` did not, so I inferred that `vcrun2022` is the correct version from this.

I tested this locally with a fresh prefix using GE-Proton9-25 and with the file in this PR in the `protonfixes/gamefixes-steam` directory. On first launch the game processes spun up and `vcrun2022` was installed, but the game still crashed on that first launch. All subsequent launches succeeded however, and the game appears to be fully playable.

Let me know if there are any other steps or investigations required on my end here. Thanks!