### PR TITLE
fix: write the game_title file in the prefix.

### DIFF
--- a/fix.py
+++ b/fix.py
@@ -61,7 +61,7 @@ def get_game_name() -> str:
                     if len(row) > 3 and row[3] == umu_id and row[1] == store:
                         title = row[0]  # Title is the first entry
                         with open(
-                            os.path.join(script_dir, 'game_title'),
+                            os.path.join(pfx, 'game_title'),
                             'w',
                             encoding='utf-8',
                         ) as file:


### PR DESCRIPTION
Line https://github.com/Open-Wine-Components/umu-protonfixes/blob/master/fix.py#L48 checks for the `game_title` file in the prefix, but the file was written in the same directory as the python script https://github.com/Open-Wine-Components/umu-protonfixes/blob/master/fix.py#L64

Tangentially, while looking for this issue, the method writes the file inside the WINEPREFIX (`.../pfx/` directory), which I think should be `STEAM_COMPAT_DATA_PATH` instead.