### PR TITLE
fix: remove game_title to-file caching mechanism from get_game_name()

### DIFF
--- a/fix.py
+++ b/fix.py
@@ -17,7 +17,7 @@ except ImportError:
     from logger import log
 
 try:
-    import __main__ as protonmain
+    import __main__ as protonmain  # noqa F401
 except ImportError:
     log.warn('Unable to hook into Proton main script environment')
 
@@ -38,7 +38,7 @@ def get_game_id() -> str:
     return None
 
 
-def get_game_title(pfx: str, database: str) -> str:
+def get_game_title(database: str) -> str:
     """Get the game name from the local umu database"""
     umu_id = os.environ['UMU_ID']
     store = os.environ.get('STORE') or 'none'
@@ -50,10 +50,6 @@ def get_game_title(pfx: str, database: str) -> str:
             for row in csvreader:
                 # Check if the row has enough columns and matches both UMU_ID and STORE
                 if len(row) > 3 and row[3] == umu_id and row[1] == store:
-                    with open(
-                        os.path.join(pfx, 'game_title'), 'w', encoding='utf-8'
-                    ) as file:
-                        file.write(row[0])
                     return row[0]
     except FileNotFoundError:
         log.warn(f'CSV file not found: {database}')
@@ -67,15 +63,10 @@ def get_game_title(pfx: str, database: str) -> str:
 
 @lru_cache
 def get_game_name() -> str:
-    """Trys to return the game name from environment variables"""
-    pfx = os.environ.get('WINEPREFIX') or protonmain.g_session.env.get('WINEPREFIX')
-
+    """Tries to return the game name from environment variables"""
     if os.environ.get('UMU_ID'):
-        if os.path.isfile(f'{pfx}/game_title'):
-            with open(f'{pfx}/game_title', encoding='utf-8') as file:
-                return file.readline()
         database = f'{os.path.dirname(os.path.abspath(__file__))}/umu-database.csv'
-        return get_game_title(pfx, database)
+        return get_game_title(database)
 
     try:
         log.debug('UMU_ID is not in environment')

--- a/protonfixes_test.py
+++ b/protonfixes_test.py
@@ -286,23 +286,6 @@ class TestProtonfixes(unittest.TestCase):
         result = fix.get_store_name(store)
         self.assertFalse(result, 'Expected None')
 
-    def testGetGameName(self):
-        """Set UMU_ID and access the game_title file for its title
-
-        The get_game_name function returns a string of the running game's
-        title.
-
-        It checks a few system paths in the user's system to try to
-        determine it, and makes a callout to an owc endpoint to get an
-        official title by its UMU_ID.
-        """
-        os.environ['UMU_ID'] = self.game_id
-        os.environ['WINEPREFIX'] = self.pfx.as_posix()
-        self.pfx.joinpath('game_title').touch()
-        func = fix.get_game_name.__wrapped__  # Do not reference the cache
-        result = func()
-        self.assertFalse(result, 'Expected an empty string')
-
     def testGetGameNameDB(self):
         """Set UMU_ID and access umu database"""
         os.environ['UMU_ID'] = 'umu-35140'
@@ -393,12 +376,12 @@ class TestProtonfixes(unittest.TestCase):
         os.environ['WINEPREFIX'] = self.pfx.as_posix()
         os.environ['STORE'] = ''
         os.environ["UMU_ID"] = 'umu-1174180'
-        result = fix.get_game_title(self.pfx.as_posix(), self.db.as_posix())
+        result = fix.get_game_title(self.db.as_posix())
         self.assertEqual(result, 'Red Dead Redemption 2')
 
         # STORE is unset
         os.environ.pop('STORE')
-        result = fix.get_game_title(self.pfx.as_posix(), self.db.as_posix())
+        result = fix.get_game_title(self.db.as_posix())
         self.assertEqual(result, 'Red Dead Redemption 2')
 
     def testGetTitleNameNoEntry(self):
@@ -410,17 +393,17 @@ class TestProtonfixes(unittest.TestCase):
         os.environ['WINEPREFIX'] = self.pfx.as_posix()
         os.environ['STORE'] = ''
         os.environ["UMU_ID"] = 'umu-default'
-        result = fix.get_game_title(self.pfx.as_posix(), self.db.as_posix())
+        result = fix.get_game_title(self.db.as_posix())
         self.assertEqual(result, 'UNKNOWN')
 
         # STORE is unset
         os.environ.pop('STORE')
-        result = fix.get_game_title(self.pfx.as_posix(), self.db.as_posix())
+        result = fix.get_game_title(self.db.as_posix())
         self.assertEqual(result, 'UNKNOWN')
 
         # STORE is valid
         os.environ['STORE'] = 'gog'
-        result = fix.get_game_title(self.pfx.as_posix(), self.db.as_posix())
+        result = fix.get_game_title(self.db.as_posix())
         self.assertEqual(result, 'UNKNOWN')
 
 if __name__ == '__main__':


### PR DESCRIPTION
When using the same prefix with multiple games with fixes, protonfixes logs an incorrect game title due to caching the game title in a file in the prefix.

With the GAMEID for The Callisto Protocol
```
(venv) loathingkernel@elitebook umu-launcher (main) $ STORE=egs GAMEID=umu-1544020 WINEPREFIX=~/Wine/umutest PROTONPATH=~/.local/share/Steam/compatibilitytools.d/GE-Proton9-26/ umu-run winecfg.exe
INFO: umu-launcher version 1.2.5 (3.13.2 (main, Feb  5 2025, 08:05:21) [GCC 14.2.1 20250128])
WARNING: Executable not found: winecfg.exe
INFO: steamrt3 is up to date
ProtonFixes[11305] INFO: Running protonfixes
ProtonFixes[11305] INFO: Running checks
ProtonFixes[11305] INFO: All checks successful
ProtonFixes[11305] INFO: Non-steam game The Callisto Protocol (umu-1544020)
ProtonFixes[11305] INFO: EGS store specified, using EGS database
ProtonFixes[11305] INFO: Using global defaults for The Callisto Protocol (umu-1544020)
ProtonFixes[11305] INFO: Checking if winetricks vcrun2022 is installed
ProtonFixes[11305] INFO: Non-steam game The Callisto Protocol (umu-1544020)
ProtonFixes[11305] INFO: EGS store specified, using EGS database
ProtonFixes[11305] INFO: No global protonfix found for The Callisto Protocol (umu-1544020)
```

With the GAMEID for GTAV
```
(venv) loathingkernel@elitebook umu-launcher (main) $ STORE=egs GAMEID=umu-271590 WINEPREFIX=~/Wine/umutest PROTONPATH=~/.local/share/Steam/compatibilitytools.d/GE-Proton9-26/ umu-run winecfg.exe
INFO: umu-launcher version 1.2.5 (3.13.2 (main, Feb  5 2025, 08:05:21) [GCC 14.2.1 20250128])
WARNING: Executable not found: winecfg.exe
INFO: steamrt3 is up to date
ProtonFixes[11597] INFO: Running protonfixes
ProtonFixes[11597] INFO: Running checks
ProtonFixes[11597] INFO: All checks successful
ProtonFixes[11597] INFO: Non-steam game The Callisto Protocol (umu-271590)
ProtonFixes[11597] INFO: EGS store specified, using EGS database
ProtonFixes[11597] INFO: Using global defaults for The Callisto Protocol (umu-271590)
ProtonFixes[11597] INFO: Checking if winetricks vcrun2022 is installed
ProtonFixes[11597] INFO: Non-steam game The Callisto Protocol (umu-271590)
ProtonFixes[11597] INFO: EGS store specified, using EGS database
ProtonFixes[11597] INFO: Using global protonfix for The Callisto Protocol (umu-271590)
ProtonFixes[11597] INFO: Removing env: SteamAppId
```


This removes the to-file caching mechanism for the game's title, and always looks it up in the csv file. The performance difference is neglible as the CSV file is still small, and the function is decorated with `@lru_cache`, which means the penalty affects it only once per launch.

Reading the cached `game_title` file
```
ProtonFixes[16530] INFO: All checks successful
game_title: 49.3990000904887 microseconds
```

Parsing the CSV file
```
ProtonFixes[17039] INFO: All checks successful
csvfile: 293.2439992946456 microseconds
```
