### PR TITLE
only say 'we did not find the game' if title is still empty after searching the csv

### DIFF
--- a/fix.py
+++ b/fix.py
@@ -61,7 +61,8 @@ def get_game_title(pfx: str, database: str) -> str:
     except Exception as ex:
         log.debug(f'Error reading CSV file: {ex}')
 
-    log.warn('Game title not found in CSV')
+    if title=='UNKNOWN':
+        log.warn('Game title not found in CSV')
 
     return title
 


### PR DESCRIPTION
This is the actual fix for the behavior I observed in https://github.com/Open-Wine-Components/umu-protonfixes/issues/259