### PR TITLE
Make import save function able to walk-up

### DIFF
--- a/util.py
+++ b/util.py
@@ -1017,7 +1017,7 @@ def import_saves_folder(
             # The user's folder in the prefix location for from_appid
             prefix = Path(
                 f'{i}/steamapps/compatdata/{from_appid}/pfx/drive_c/users/steamuser/{relative_path}'
-            )
+            ).resolve()
             if not prefix.exists():
                 # Better to just abort than create a broken symlink
                 log.info(
@@ -1032,7 +1032,7 @@ def import_saves_folder(
         )
         return False
     # Create the symlink
-    goal = Path(f'{protonprefix()}/drive_c/users/steamuser/{relative_path}')
+    goal = Path(f'{protonprefix()}/drive_c/users/steamuser/{relative_path}').resolve()
     # The goal is where we intend to create the symlink
     if not goal.exists():
         # Create the necessary parent folders if needed


### PR DESCRIPTION
Adds ability to walk-up paths to import save function. Some games (notably Monster Hunter, like https://github.com/Open-Wine-Components/umu-protonfixes/issues/247) save their files in a steam cloud folder in the program files in the prefix and currently can't be accessed from the user folder.

I'm not sure if this is the best way to do it, but it seems to not break any compatibility with current implementation.