### PR TITLE
Wuthering Waves (3513350) fixes

### DIFF
--- a/gamefixes-steam/3513350.py
+++ b/gamefixes-steam/3513350.py
@@ -10,8 +10,6 @@ def main() -> None:
        This disables Proton mfplat at the cost
        of in-game experience for now.
     """
-    util.disable_protonmediaconverter()
-    util.winedll_override('winegstreamer', '')
     util.winedll_override('mfplat', 'd')
     """In-game browser fix.
     """

--- a/gamefixes-steam/3513350.py
+++ b/gamefixes-steam/3513350.py
@@ -1,0 +1,18 @@
+"""Wuthering Waves - ID 3513350
+https://www.protondb.com/app/3513350
+"""
+
+from protonfixes import util
+
+
+def main() -> None:
+    """Video playback glitches in 2.1+ content
+       This disables Proton mfplat at the cost
+       of in-game experience for now.
+    """
+    util.disable_protonmediaconverter()
+    util.winedll_override('winegstreamer', '')
+    util.winedll_override('mfplat', 'd')
+    """In-game browser fix.
+    """
+    util.wineexe_override('KRSDKExternal', 'd')

--- a/gamefixes-steam/3513350.py
+++ b/gamefixes-steam/3513350.py
@@ -11,6 +11,5 @@ def main() -> None:
    of in-game experience for now.
    """
    util.winedll_override('mfplat', 'd')
-   """In-game browser fix.
-   """
+   """In-game browser fix."""
    util.wineexe_override('KRSDKExternal', 'd')

--- a/gamefixes-steam/3513350.py
+++ b/gamefixes-steam/3513350.py
@@ -6,11 +6,11 @@ from protonfixes import util
 
 
 def main() -> None:
-    """Video playback glitches in 2.1+ content
-       This disables Proton mfplat at the cost
-       of in-game experience for now.
-    """
-    util.winedll_override('mfplat', 'd')
-    """In-game browser fix.
-    """
-    util.wineexe_override('KRSDKExternal', 'd')
+   """Video playback glitches in 2.1+ content
+   This disables Proton mfplat at the cost
+   of in-game experience for now.
+   """
+   util.winedll_override('mfplat', 'd')
+   """In-game browser fix.
+   """
+   util.wineexe_override('KRSDKExternal', 'd')

--- a/gamefixes-umu/umu-3513350.py
+++ b/gamefixes-umu/umu-3513350.py
@@ -13,3 +13,12 @@ def main() -> None:
    util.winedll_override('mfplat', 'd')
    """In-game browser fix."""
    util.wineexe_override('KRSDKExternal', 'd')
+   """Font fixes for in-game resources, if any."""
+   util.protontricks('sourcehansans')
+   util.protontricks('fakechinese')
+   util.protontricks('corefonts')
+   """Set SteamGameId so that non-steam versions can
+   pick up steam-specific fixes in proton's wine code
+   if, when and should such fixes ever land.
+   """
+   util.set_environment('SteamGameId', '3513350')

--- a/util.py
+++ b/util.py
@@ -410,14 +410,22 @@ def get_game_install_path() -> str:
     return install_path
 
 
-def winedll_override(dll: str, dtype: Literal['n', 'b', 'n,b', 'b,n', '']) -> None:
-    """Add WINE dll override"""
-    log.info(f'Overriding {dll}.dll = {dtype}')
-    setting = f'{dll}={dtype}'
+def winepe_override(target: str, filetype: str, dtype: Literal['n', 'b', 'n,b', 'b,n', '']) -> None:
+    """Add WINE file override"""
+    log.info(f'Overriding {target}.{filetype} = {dtype}')
+    target_file = target if filetype == "dll" else f'{target}.{filetype}'
+    setting = f'{target_file}={dtype}'
     protonmain.append_to_env_str(
         protonmain.g_session.env, 'WINEDLLOVERRIDES', setting, ';'
     )
 
+def winedll_override(dll: str, dtype: Literal['n', 'b', 'n,b', 'b,n', '']) -> None:
+    """Add WINE dll override"""
+    winefile_override(target=dll, filetype="dll", dtype=dtype)
+
+def wineexe_override(exe: str, dtype: Literal['n', 'b', 'n,b', 'b,n', '']) -> None:
+    """Add WINE executable override"""
+    winefile_override(target=exe, filetype="exe", dtype=dtype)
 
 def patch_libcuda() -> bool:
     """Patches libcuda to work around games that crash when initializing libcuda and are using DLSS.

--- a/util.py
+++ b/util.py
@@ -421,11 +421,11 @@ def winepe_override(target: str, filetype: str, dtype: Literal['n', 'b', 'n,b', 
 
 def winedll_override(dll: str, dtype: Literal['n', 'b', 'n,b', 'b,n', '']) -> None:
     """Add WINE dll override"""
-    winefile_override(target=dll, filetype="dll", dtype=dtype)
+    winepe_override(target=dll, filetype="dll", dtype=dtype)
 
 def wineexe_override(exe: str, dtype: Literal['n', 'b', 'n,b', 'b,n', '']) -> None:
     """Add WINE executable override"""
-    winefile_override(target=exe, filetype="exe", dtype=dtype)
+    winepe_override(target=exe, filetype="exe", dtype=dtype)
 
 def patch_libcuda() -> bool:
     """Patches libcuda to work around games that crash when initializing libcuda and are using DLSS.

--- a/util.py
+++ b/util.py
@@ -410,7 +410,7 @@ def get_game_install_path() -> str:
     return install_path
 
 
-def winepe_override(target: str, filetype: str, dtype: Literal['n', 'b', 'n,b', 'b,n', '']) -> None:
+def _winepe_override(target: str, filetype: str, dtype: Literal['n', 'b', 'n,b', 'b,n', '']) -> None:
     """Add WINE file override"""
     log.info(f'Overriding {target}.{filetype} = {dtype}')
     target_file = target if filetype == "dll" else f'{target}.{filetype}'
@@ -421,11 +421,11 @@ def winepe_override(target: str, filetype: str, dtype: Literal['n', 'b', 'n,b', 
 
 def winedll_override(dll: str, dtype: Literal['n', 'b', 'n,b', 'b,n', '']) -> None:
     """Add WINE dll override"""
-    winepe_override(target=dll, filetype="dll", dtype=dtype)
+    _winepe_override(target=dll, filetype="dll", dtype=dtype)
 
 def wineexe_override(exe: str, dtype: Literal['n', 'b', 'n,b', 'b,n', '']) -> None:
     """Add WINE executable override"""
-    winepe_override(target=exe, filetype="exe", dtype=dtype)
+    _winepe_override(target=exe, filetype="exe", dtype=dtype)
 
 def patch_libcuda() -> bool:
     """Patches libcuda to work around games that crash when initializing libcuda and are using DLSS.


### PR DESCRIPTION
* Rename `winedll_override` to `winepe_override` to make it reusable with new utility methods `winedll_override` and `wineexe_override`
* Add Wuthering Waves fixes (provisional, based on current game runtime), required workarounds notwithstanding
