### PR TITLE
Add pre-commit config to run ruff before commits

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.11.2
+  hooks:
+    - id: ruff


### PR DESCRIPTION
This should hopefully make it a little harder for us to accidentally break CI

To set this up, install [pre-commit](<https://pre-commit.com/>) and run `pre-commit install` in the repo directory. Any future commits will then abort if `ruff` doesn't pass (note that it only checks staged changes)

In the future the config file might be expanded to run other scripts too, for now I figured ruff was enough