### PR TITLE
Refactor: fixed module resolution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,12 +40,15 @@ jobs:
         run: |
           python3 .github/scripts/check_gamefixes.py
           python3 .github/scripts/check_verbs.py
-      - name: Validate gamefix imports 
+      # We need a known parent package in the unit tests, so we need to change to the parent dir
+      # As "umu-protonfixes" is not a valid package name, we create a symbolic link to "protonfixes"
+      - name: Fix package resolution
         run: |
-          cd ..
-          ln -s umu-protonfixes protonfixes
-          cd protonfixes
+          ln -s umu-protonfixes ../protonfixes
+      - name: Validate gamefix imports
+        run: |
           python3 .github/scripts/check_imports.py
       - name: Test with unittest
         run: |
-          python3 protonfixes_test.py
+          cd ..
+          python3 -m protonfixes.protonfixes_test

--- a/__init__.py
+++ b/__init__.py
@@ -1,18 +1,42 @@
-"""Starts the protonfix module"""
+"""Starts the protonfix module and runs fixes after pre-flight-checks"""
 
 import os
 import sys
+import traceback
 
-RUN_CONDITIONS = [
-    'STEAM_COMPAT_DATA_PATH' in os.environ,
-    'PROTONFIXES_DISABLE' not in os.environ,
-    'waitforexitandrun' in sys.argv[1],
-]
+from . import fix
+from .logger import log
 
-if all(RUN_CONDITIONS):
-    import traceback
-    from . import fix
 
+def check_conditions() -> bool:
+    """Determine, if the actual game was executed and protonfixes isn't deactivated.
+
+    Returns:
+        bool: True, if the fix should be executed.
+
+    """
+    return len(sys.argv) >= 1 and \
+        'STEAM_COMPAT_DATA_PATH' in os.environ and \
+        'PROTONFIXES_DISABLE' not in os.environ and \
+        'waitforexitandrun' in sys.argv[1]
+
+
+def check_iscriptevaluator() -> bool:
+    """Determine, if we were invoked while running "iscriptevaluator.exe".
+
+    Returns:
+        bool: True, if we were invoked while running "iscriptevaluator.exe".
+
+    """
+    return len(sys.argv) >= 3 and \
+        'iscriptevaluator.exe' in sys.argv[2]
+
+
+if check_iscriptevaluator():
+    log.debug('Skipping fix execution. We are running "iscriptevaluator.exe".')
+elif not check_conditions():
+    log.warn('Skipping fix execution. We are probably running an unit test.')
+else:
     try:
         fix.main()
 

--- a/checks.py
+++ b/checks.py
@@ -1,9 +1,6 @@
 """Run some tests and generate warnings for proton configuration issues"""
 
-try:
-    from .logger import log
-except ImportError:
-    from logger import log
+from .logger import log
 
 
 def esync_file_limits() -> bool:

--- a/config.py
+++ b/config.py
@@ -1,12 +1,9 @@
 """Load configuration settings for protonfixes"""
 
 import os
-from configparser import ConfigParser
 
-try:
-    from .logger import log
-except ImportError:
-    from logger import log
+from configparser import ConfigParser
+from .logger import log
 
 
 CONF_FILE = '~/.config/protonfixes/config.ini'

--- a/engine.py
+++ b/engine.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+
 from .logger import log
 
 

--- a/fix.py
+++ b/fix.py
@@ -4,17 +4,13 @@ import os
 import re
 import sys
 import csv
+
 from functools import lru_cache
 from importlib import import_module
 
-try:
-    from . import config
-    from .checks import run_checks
-    from .logger import log
-except ImportError:
-    import config
-    from checks import run_checks
-    from logger import log
+from . import config
+from .checks import run_checks
+from .logger import log
 
 try:
     import __main__ as protonmain  # noqa F401

--- a/protonfixes_test.py
+++ b/protonfixes_test.py
@@ -1,11 +1,13 @@
-import unittest
+import io
 import os
 import tempfile
+import unittest
+import urllib.request
+
 from pathlib import Path
 from unittest.mock import patch, mock_open
-import io
-import urllib.request
-import fix
+
+from . import fix
 
 
 class TestProtonfixes(unittest.TestCase):
@@ -308,7 +310,7 @@ class TestProtonfixes(unittest.TestCase):
 
         with patch('builtins.open', mock_open()) as mocked_open:
             mocked_open.side_effect = FileNotFoundError
-            with patch('fix.log') as mocked_log:  # Mock the logger separately
+            with patch('protonfixes.fix.log') as mocked_log:  # Mock the logger separately
                 func = fix.get_game_name.__wrapped__  # Do not reference the cache
                 result = func()
                 self.assertEqual(result, 'UNKNOWN')
@@ -322,7 +324,7 @@ class TestProtonfixes(unittest.TestCase):
 
         with patch('builtins.open', mock_open()) as mocked_open:
             mocked_open.side_effect = OSError
-            with patch('fix.log') as mocked_log:  # Mock the logger separately
+            with patch('protonfixes.fix.log') as mocked_log:  # Mock the logger separately
                 func = fix.get_game_name.__wrapped__  # Do not reference the cache
                 result = func()
                 self.assertEqual(result, 'UNKNOWN')
@@ -350,7 +352,7 @@ class TestProtonfixes(unittest.TestCase):
 
         with patch('builtins.open', mock_open()) as mocked_open:
             mocked_open.side_effect = UnicodeDecodeError('utf-8', b'', 0, 1, '')
-            with patch('fix.log') as mocked_log:  # Mock the logger separately
+            with patch('protonfixes.fix.log') as mocked_log:  # Mock the logger separately
                 func = fix.get_game_name.__wrapped__  # Do not reference the cache
                 result = func()
                 self.assertEqual(result, 'UNKNOWN')

--- a/util.py
+++ b/util.py
@@ -1,7 +1,6 @@
 """Utilities to make gamefixes easier"""
 
 import configparser
-from io import TextIOWrapper
 import os
 import sys
 import re
@@ -12,16 +11,14 @@ import zipfile
 import subprocess
 import urllib.request
 import functools
+
+from io import TextIOWrapper
 from socket import socket, AF_INET, SOCK_DGRAM
 from typing import Literal, Any, Callable, Union
 from collections.abc import Mapping, Generator
 
-try:
-    from .logger import log
-    from .steamhelper import install_app
-except ImportError:
-    from logger import log
-    from steamhelper import install_app
+from .logger import log
+from .steamhelper import install_app
 
 try:
     import __main__ as protonmain


### PR DESCRIPTION
Supersedes #200, without the relative imports in the gamefixes.
This patch should allow the failed #202 to work.

- Fixed relative imports
- Removed import handling via ImportError exception
- Fixed CI by running via module, instead of file
- Added / improved handling in __init__.py for unit tests