### PR TITLE
`SteamDeck=1` for The Last of Us Part 2 Remastered

### DIFF
--- a/gamefixes-steam/2531310.py
+++ b/gamefixes-steam/2531310.py
@@ -1,0 +1,8 @@
+"""The Last of Us Part 2 Remastered"""
+
+from protonfixes import util
+
+
+def main() -> None:
+    """Fixes the game not starting for some people, but it doesn't work for everyone though. Cause has yet to be determined."""
+    util.set_environment('SteamDeck', '1')


### PR DESCRIPTION
Looking at https://github.com/ValveSoftware/Proton/issues/8585#issuecomment-2776568529, it looks like this game is seeing a similar issue to God of War Ragnarok, where it fails to start due to an error with PSSDK, despite PSN being optional for this game. This workaround, however, does not seem to work for everybody, and there's currently no explanation for why this is.