### PR TITLE
Add build target for unzip

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,4 +20,5 @@ jobs:
           fetch-depth: 0
       - name: Build umu-protonfixes
         run: |
+          export DEB_BUILD_MAINT_OPTIONS=hardening=-format
           make

--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "subprojects/umu-database"]
         path = subprojects/umu-database
         url = https://github.com/Open-Wine-Components/umu-database
+[submodule "subprojects/unzip"]
+	path = subprojects/unzip
+	url = https://salsa.debian.org/sanvila/unzip.git

--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,11 @@ INSTALL_DIR ?= $(shell pwd)/dist/protonfixes
 
 .PHONY: all
 
-all: xrandr-dist cabextract-dist libmspack-dist
+all: xrandr-dist cabextract-dist libmspack-dist unzip-dist
 
 .PHONY: install
 
-install: protonfixes-install xrandr-install cabextract-install libmspack-install
+install: protonfixes-install xrandr-install cabextract-install libmspack-install unzip-install
 
 #
 # protonfixes

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ all: xrandr-dist cabextract-dist libmspack-dist unzip-dist
 
 .PHONY: install
 
+# Note: `export DEB_BUILD_MAINT_OPTIONS=hardening=-format` is required for the unzip target
 install: protonfixes-install xrandr-install cabextract-install libmspack-install unzip-install
 
 #

--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,6 @@ $(OBJDIR)/.build-unzip-dist: | $(OBJDIR)
 	$(info :: Building unzip )
 	cd subprojects/unzip && \
 	dpkg-source --before-build . && \
-	export DEB_BUILD_MAINT_OPTIONS=hardening=-format && \
 	make -f unix/Makefile prefix=/usr D_USE_BZ2=-DUSE_BZIP2 L_BZ2=-lbz2 CC="$(CC) -Wall" LF2="$(LDFLAGS)" CF="$(CFLAGS) $(CPPFLAGS) -I. $(DEFINES)" unzips
 	touch $(@)
 


### PR DESCRIPTION
Attempting to install the `xaudio29` verb inside a clean wine prefix, it's observed that the installation can fail when running it through 7z.exe on GE-Proton9-27:

```
[2025-04-03 22:44:07] Executing /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton9-27/files/bin/wine 
C:\Program Files (x86)\7-Zip\7z.exe x Y:\xaudio29\microsoft.xaudio2.redist.1.2.11.nupkg -oC:\windows\temp\_xaudi
o29
wine: failed to open "C:\\Program Files (x86)\\7-Zip\\7z.exe": c0000135
-----------------------------------------------------
warning: Note: command /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton9-27/files/bin/wine C:\Program Files (x86)^G-Zip^Gz.exe x Y:\xaudio29\microsoft.xaudio2.redist.1.2.11.nupkg -oC:\windows       emp\_xaudio29 returned status 53. Aborting.
------------------------------------------------------
ProtonFixes[4440] WARN: Winetricks failed running verb "xaudio29" with status 1.
```

Using an `unzip` executable built against the Steam Runtime fixed this issue.