### PR TITLE
Add save import for Persona 3 Reload and Metaphor ReFantazio

### DIFF
--- a/gamefixes-steam/2161700.py
+++ b/gamefixes-steam/2161700.py
@@ -1,0 +1,8 @@
+"""Persona 3 Reload"""
+
+from protonfixes import util
+
+
+def main() -> None:
+    """Imports demo saves into the full game."""
+    util.import_saves_folder(3358440, f'AppData/Roaming/SEGA/P3R/Steam/{util.get_steam_account_id()}', True)

--- a/gamefixes-steam/2679460.py
+++ b/gamefixes-steam/2679460.py
@@ -1,0 +1,8 @@
+"""Metaphor ReFantazio"""
+
+from protonfixes import util
+
+
+def main() -> None:
+    """Imports demo saves into the full game."""
+    util.import_saves_folder(3130330, f'AppData/Roaming/SEGA/METAPHOR/Steam/{util.get_steam_account_id()}', True)


### PR DESCRIPTION
Both games let you continue saves made from their demo versions.