### PR TITLE
fix check_conditions in __init__ when there is only 1 sys.argv

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -16,7 +16,7 @@ def check_conditions() -> bool:
 
     """
     return (
-        len(sys.argv) >= 1
+        len(sys.argv) >= 2
         and 'STEAM_COMPAT_DATA_PATH' in os.environ
         and 'PROTONFIXES_DISABLE' not in os.environ
         and 'waitforexitandrun' in sys.argv[1]


### PR DESCRIPTION
the original check can trigger this error:
'waitforexitandrun' in sys.argv[1]
IndexError: list index out of range

to select [1] you need atleas a len of 2