### PR TITLE
game fix: Once Human on Steam

### DIFF
--- a/gamefixes-steam/2139460.py
+++ b/gamefixes-steam/2139460.py
@@ -1,0 +1,8 @@
+"""Game fix for Once Human"""
+
+from protonfixes import util
+
+
+def main() -> None:
+    """Advertises drive space to fixing caching"""
+    util.set_environment('PROTON_SET_GAME_DRIVE', '1')


### PR DESCRIPTION
Once Human can't cache game data if it can't determine how much disk space is available.

Game is F2P and severe performance problems are readily apparent when testing. Advertising the disk space seems to address most of them (though some remain). If testing using AMD, depending on MESA version, set `RADV_DEBUG=nodcc,nohiz` to avoid a game crash.