### PR TITLE
update util.patch_libcuda

### DIFF
--- a/gamefixes-umu/umu-starcitizen.py
+++ b/gamefixes-umu/umu-starcitizen.py
@@ -1,15 +1,25 @@
 """Game fix for Star Citizen"""
 
+import os
 from protonfixes import util
 
 
 def main() -> None:
     # patch libcuda to workaround crashes related to DLSS
     # See: https://github.com/jp7677/dxvk-nvapi/issues/174#issuecomment-2227462795
-    util.patch_libcuda()
+    patched = util.patch_libcuda()
+    if patched:
+        # Satisfy check for the existence of these dlls when trying to initialize ngx
+        # Copy an existing DLL to these three names
+        env_path = os.path.join(util.protonprefix(), 'drive_c', 'windows', 'system32')
+        dest_files = ['cryptbase.dll', 'devobj.dll', 'drvstore.dll']
+        for file in dest_files:
+            link_path = os.path.join(env_path, file)
+            if not os.path.isfile(link_path):
+                os.symlink('security.dll', link_path)
 
     # RSI Launcher depends on powershell
     util.protontricks('powershell')
 
     # RSI Launcher animation
-    util.winedll_override('libglesv2', 'builtin')
+    util.winedll_override('libglesv2', 'b')

--- a/util.py
+++ b/util.py
@@ -516,7 +516,8 @@ def patch_libcuda() -> bool:
             return False
 
         log.info(f'Patched libcuda.so saved to: {patched_library}')
-        set_environment('LD_PRELOAD', patched_library)
+        protonmain.g_session.env['LD_LIBRARY_PATH'] = f'{os.path.dirname(patched_library)}:{protonmain.g_session.env["LD_LIBRARY_PATH"]}'
+
         return True
 
     except Exception as e:


### PR DESCRIPTION
- Star Citizen's easy anti-cheat clears values from LD_PRELOAD such that the patched libcuda is not used. Instead use LD_LIBRARY_PATH which is not presently overridden. 
- The game checks for the existence of these dlls when trying to initialize ngx. To satisfy this validation an existing dll is copied to the three names
  -  cryptbase.dll
  - devobj.dll
  - drvstore.dll