### PR TITLE
Add fix for Yosumin

### DIFF
--- a/gamefixes-steam/23300.py
+++ b/gamefixes-steam/23300.py
@@ -1,0 +1,8 @@
+"""Yosumin"""
+
+from protonfixes import util
+
+
+def main() -> None:
+    """Works around a Wine bug causing the game to crash."""
+    util.protontricks('d3dx9')


### PR DESCRIPTION
This works around a Wine bug that is causing the game to crash, as described in ValveSoftware/Proton#8608.