### PR TITLE
fix: use correct values when overriding wine DLLs

### DIFF
--- a/gamefixes-steam/105000.py
+++ b/gamefixes-steam/105000.py
@@ -7,4 +7,4 @@ from protonfixes import util
 
 
 def main() -> None:
-    util.winedll_override('xaudio2_7', 'd')
+    util.winedll_override('xaudio2_7', '')

--- a/gamefixes-steam/206480.py
+++ b/gamefixes-steam/206480.py
@@ -8,4 +8,4 @@ def main() -> None:
     """Disable libglesv2"""
     # gpu acelleration on wibed3d https://bugs.winehq.org/show_bug.cgi?id=44985
     # Make the store work.
-    util.winedll_override('libglesv2', 'd')
+    util.winedll_override('libglesv2', '')

--- a/gamefixes-steam/212500.py
+++ b/gamefixes-steam/212500.py
@@ -169,7 +169,7 @@ def main() -> None:
     """Disable libglesv2"""
     ## gpu acceleration on wined3d https://bugs.winehq.org/show_bug.cgi?id=44985
     # Make the store work.
-    util.winedll_override('libglesv2', 'd')
+    util.winedll_override('libglesv2', '')
     # Fix visible mouse in middle of screen while rotating camera
     # This needs to run as a subprocess while the game is running,
     # the proces will close itself when the game window isn't detected for 30 seconds

--- a/gamefixes-steam/230820.py
+++ b/gamefixes-steam/230820.py
@@ -7,4 +7,4 @@ from protonfixes import util
 
 
 def main() -> None:
-    util.winedll_override('xaudio2_7', 'd')
+    util.winedll_override('xaudio2_7', '')

--- a/gamefixes-steam/243200.py
+++ b/gamefixes-steam/243200.py
@@ -7,4 +7,4 @@ from protonfixes import util
 
 
 def main() -> None:
-    util.winedll_override('xaudio2_7', 'd')
+    util.winedll_override('xaudio2_7', '')

--- a/gamefixes-steam/506510.py
+++ b/gamefixes-steam/506510.py
@@ -5,4 +5,4 @@ from protonfixes import util
 
 def main() -> None:
     """Fixes game getting stuck on a white screen."""
-    util.winedll_override('dcomp', 'd')
+    util.winedll_override('dcomp', '')

--- a/gamefixes-steam/968370.py
+++ b/gamefixes-steam/968370.py
@@ -6,5 +6,5 @@ from protonfixes import util
 
 
 def main() -> None:
-    util.winedll_override('d3d9', 'd')
+    util.winedll_override('d3d9', '')
     util.protontricks('segoe_script')

--- a/gamefixes-umu/umu-3513350.py
+++ b/gamefixes-umu/umu-3513350.py
@@ -10,7 +10,7 @@ def main() -> None:
     This disables Proton mfplat at the cost
     of in-game experience for now.
     """
-    util.winedll_override('mfplat', 'd')
+    util.winedll_override('mfplat', '')
     """In-game browser fix."""
     util.wineexe_override('KRSDKExternal', 'd')
     """Font fixes for in-game resources, if any."""

--- a/gamefixes-umu/umu-silenthill3.py
+++ b/gamefixes-umu/umu-silenthill3.py
@@ -6,4 +6,4 @@ from protonfixes import util
 def main() -> None:
     # Needs directmusic for some cutscenes
     util.protontricks('directmusic')
-    util.winedll_override('dsound', 'builtin')
+    util.winedll_override('dsound', 'b')


### PR DESCRIPTION
A change to the `winedll_override` interface had invalidated a few fixes such as Star Citizen for a while. In the near future, we need to use a static type checker in our gamefixes to prevent cases like this.

See https://gitlab.winehq.org/wine/wine/-/wikis/Wine-User's-Guide#winedlloverrides-dll-overrides
