### PR TITLE
Install `physx` for The Testament of Sherlock Holmes

### DIFF
--- a/gamefixes-steam/205650.py
+++ b/gamefixes-steam/205650.py
@@ -1,0 +1,8 @@
+"""The Testament of Sherlock Holmes"""
+
+from protonfixes import util
+
+
+def main() -> None:
+    """Needs to have PhysX installed to work, even for systems not using Nvidia."""
+    util.protontricks('physx')


### PR DESCRIPTION
Looking at ProtonDB reports for this game, it looks like it needs to have PhysX installed for it to work, even on systems not using Nvidia.

https://www.protondb.com/app/205650?device=any