### PR TITLE
gamefixes: Add Celeste fix for EGS build

### DIFF
--- a/gamefixes-egs/umu-504230.py
+++ b/gamefixes-egs/umu-504230.py
@@ -1,0 +1,9 @@
+"""Celeste"""
+# EGS-ID Salt
+
+from protonfixes import util
+
+
+def main() -> None:
+    util.set_environment('FNA3D_FORCE_DRIVER','OpenGL')
+    # Vulkan is broken in the EGS build


### PR DESCRIPTION
Add `FNA3D_FORCE_DRIVER=OpenGL` to ensure that Vulkan is not used and that OpenGL is used.