### PR TITLE
Add Marvel Rivals (EGS) fixes

### DIFF
--- a/gamefixes-egs/umu-2767030.py
+++ b/gamefixes-egs/umu-2767030.py
@@ -1,0 +1,16 @@
+"""Game fix for Marvel Rivals"""
+# EGS-ID 575efd0b5dd54429b035ffc8fe2d36d0
+
+from protonfixes import util
+
+
+def main() -> None:
+
+    util.replace_command('epic_launch_helper.exe', 'MarvelRivals_Launcher.exe')
+
+    # Set SteamGameId so that non-steam versions can pick up steam-specific fixes in proton's wine code
+    util.set_environment('SteamGameId', '2767030')
+    
+    # Set SteamDeck=1 to be able to launch the game
+    util.set_environment('SteamDeck', '1')
+

--- a/gamefixes-egs/umu-2767030.py
+++ b/gamefixes-egs/umu-2767030.py
@@ -7,9 +7,6 @@ from protonfixes import util
 def main() -> None:
 
     util.replace_command('epic_launch_helper.exe', 'MarvelRivals_Launcher.exe')
-
-    # Set SteamGameId so that non-steam versions can pick up steam-specific fixes in proton's wine code
-    util.set_environment('SteamGameId', '2767030')
     
     # Set SteamDeck=1 to be able to launch the game
     util.set_environment('SteamDeck', '1')


### PR DESCRIPTION
Replace target exe and set `SteamDeck=1`

The EGS version does not launch with the default .exe file or without setting `SteamDeck=1`.

This also coincides with an update to `umu-database.csv` at https://github.com/Open-Wine-Components/umu-database/pull/89