### PR TITLE
fix: disable wmvdecod.dll for Full Metal Daemon Muramasa

### DIFF
--- a/gamefixes-gog/umu-1209310984.py
+++ b/gamefixes-gog/umu-1209310984.py
@@ -5,3 +5,4 @@ from protonfixes import util
 
 def main() -> None:
     util.disable_protonmediaconverter()
+    util.winedll_override('wmvdecod', util.OverrideOrder.DISABLED)


### PR DESCRIPTION
Not disabling wmvdecod.dll results in Gstreamer plugins failing to load in GE-Proton built at https://github.com/GloriousEggroll/proton-ge-custom/commit/2146f1fbe016e31b6f39072b4cd2516ccf02dd77.

Traceback:
```
5249.264:00e4:00e8:trace:loaddll:build_module Loaded L"C:\\windows\\system32\\wmvdecod.dll" at 78910000: builtin
5249.265:00e4:00e8:trace:loaddll:build_module Loaded L"C:\\windows\\system32\\winegstreamer.dll" at 78880000: builtin

(wine:12752): GStreamer-WARNING **: 18:46:03.156: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstlegacyrawparse.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstlegacyrawparse.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.156: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstdvbsuboverlay.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstdvbsuboverlay.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.157: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstadpcmdec.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstadpcmdec.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.157: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstgeometrictransform.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstgeometrictransform.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.157: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstinterlace.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstinterlace.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.157: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstaudioparsers.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstaudioparsers.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.157: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstpnm.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstpnm.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.157: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstivfparse.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstivfparse.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.157: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstvideoconvertscale.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstvideoconvertscale.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.157: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstkms.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstkms.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.157: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstautoconvert.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstautoconvert.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.158: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstcodectimestamper.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstcodectimestamper.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.158: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstaudiolatency.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstaudiolatency.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.158: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgsty4mdec.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgsty4mdec.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.158: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstid3tag.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstid3tag.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.158: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstdvdspu.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstdvdspu.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.158: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstaudiofxbad.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstaudiofxbad.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.158: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstjpegformat.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstjpegformat.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.158: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstdvdsub.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstdvdsub.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.158: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstplayback.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstplayback.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.158: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstlibav.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstlibav.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.158: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstaudioconvert.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstaudioconvert.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.159: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstrfbsrc.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstrfbsrc.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.159: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstmpg123.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstmpg123.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.159: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstopenal.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstopenal.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.159: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstrtpmanagerbad.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstrtpmanagerbad.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.159: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstproxy.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstproxy.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.159: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstcoreelements.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstcoreelements.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.159: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstmidi.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstmidi.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.159: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstaudiovisualizers.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstaudiovisualizers.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.159: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstfieldanalysis.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstfieldanalysis.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.159: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgsthls.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgsthls.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.159: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstnetsim.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstnetsim.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.159: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstdvbsubenc.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstdvbsubenc.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.160: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstvorbis.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstvorbis.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.160: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstmatroska.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstmatroska.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.160: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstclosedcaption.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstclosedcaption.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.160: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstasf.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstasf.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.160: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstvideofiltersbad.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstvideofiltersbad.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.160: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstgaudieffects.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstgaudieffects.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.160: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstvideoparsersbad.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstvideoparsersbad.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.160: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgsttheora.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgsttheora.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.160: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstdvdlpcmdec.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstdvdlpcmdec.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.160: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstid3demux.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstid3demux.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.160: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstaccurip.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstaccurip.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.161: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstgtkwayland.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstgtkwayland.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.161: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstswitchbin.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstswitchbin.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.161: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstmpegtsdemux.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstmpegtsdemux.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.161: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstvideobox.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstvideobox.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.161: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstnavigationtest.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstnavigationtest.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.161: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstadder.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstadder.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.161: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstflac.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstflac.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.161: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstspeed.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstspeed.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.161: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstasfmux.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstasfmux.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.161: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstcodecalpha.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstcodecalpha.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.161: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstopengl.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstopengl.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.161: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstapetag.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstapetag.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.162: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstmpegpsmux.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstmpegpsmux.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.162: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstdeinterlace.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstdeinterlace.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.162: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstadaptivedemux2.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstadaptivedemux2.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.162: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstximagesink.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstximagesink.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.162: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstvpx.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstvpx.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.162: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstvmnc.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstvmnc.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.162: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstavi.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstavi.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.162: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstdtls.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstdtls.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.162: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstgdp.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstgdp.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.162: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstadpcmenc.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstadpcmenc.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.162: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstvideoframe_audiolevel.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstvideoframe_audiolevel.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.162: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstmpegpsdemux.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstmpegpsdemux.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.162: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstapp.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstapp.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.163: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstshm.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstshm.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.163: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstsegmentclip.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstsegmentclip.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.163: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstpbtypes.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstpbtypes.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.163: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstdash.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstdash.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.163: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstdebug.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstdebug.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.163: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstaudiomixmatrix.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstaudiomixmatrix.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.163: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstcolormanagement.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstcolormanagement.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.163: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstsctp.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstsctp.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.163: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstfestival.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstfestival.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.163: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstfrei0r.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstfrei0r.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.163: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgsttranscode.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgsttranscode.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.164: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstrawparse.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstrawparse.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.164: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstvideosignal.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstvideosignal.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.164: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstuvch264.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstuvch264.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.164: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstspeex.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstspeex.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.164: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstdvb.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstdvb.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.164: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstmxf.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstmxf.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.164: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstsubenc.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstsubenc.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.164: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstwebp.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstwebp.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.164: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstttmlsubs.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstttmlsubs.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.164: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstaes.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstaes.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.165: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstcoloreffects.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstcoloreffects.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.165: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstrealmedia.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstrealmedia.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.165: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstv4l2codecs.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstv4l2codecs.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.165: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstxingmux.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstxingmux.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.165: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstfreeverb.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstfreeverb.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.165: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstpcapparse.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstpcapparse.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.165: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstopusparse.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstopusparse.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.165: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstrtponvif.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstrtponvif.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.165: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstfaceoverlay.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstfaceoverlay.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.165: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstaiff.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstaiff.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.165: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstsmoothstreaming.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstsmoothstreaming.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.165: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstvideofilter.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstvideofilter.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.165: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstsiren.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstsiren.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.166: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgsty4menc.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgsty4menc.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.166: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstbz2.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstbz2.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.166: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstwaylandsink.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstwaylandsink.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.166: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstcamerabin.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstcamerabin.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.166: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstbayer.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstbayer.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.166: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstdav1d.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstdav1d.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.166: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstjpeg.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstjpeg.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.166: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstsndfile.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstsndfile.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.166: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstmpegtsmux.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstmpegtsmux.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.166: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstdebugutilsbad.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstdebugutilsbad.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.166: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstrist.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstrist.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.166: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstremovesilence.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstremovesilence.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.167: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstsdpelem.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstsdpelem.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.167: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstjp2kdecimator.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstjp2kdecimator.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.167: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgsttimecode.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgsttimecode.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.167: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstisomp4.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstisomp4.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.167: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstsoup.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstsoup.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.167: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstopus.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstopus.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.167: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstaudioresample.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstaudioresample.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.167: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstrtmp2.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstrtmp2.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.167: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstivtc.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstivtc.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.167: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstsmooth.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstsmooth.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.167: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstautodetect.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstautodetect.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.167: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstaudiobuffersplit.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstaudiobuffersplit.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.167: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstflv.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstflv.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.168: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstinter.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstinter.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.168: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgsttypefindfunctions.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgsttypefindfunctions.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.168: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstwavparse.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstwavparse.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.168: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstogg.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstogg.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.168: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstcoretracers.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstcoretracers.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.168: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstipcpipeline.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstipcpipeline.so: wrong ELF class: ELFCLASS64

(wine:12752): GStreamer-WARNING **: 18:46:03.168: Failed to load plugin '/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstflxdec.so': /home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton10-1/files/lib/x86_64-linux-gnu/gstreamer-1.0/libgstflxdec.so: wrong ELF class: ELFCLASS64
```

OS: SteamOS (3.7.5)
depot: 3.0.20250408.124536
pressure-vessel: 0.20250408.0 scout
scripts: 0.20250408.0
sniper: 3.0.20250408.124536 sniper 3.0.20250408.124536
Kernel: Linux 6.11.11-valve12-1-neptune-611-g517a46b477e1