### PR TITLE
add fixes for mashed

### DIFF
--- a/gamefixes-steam/281280.py
+++ b/gamefixes-steam/281280.py
@@ -1,0 +1,12 @@
+"""Game fix for Mashed(281280)"""
+
+from protonfixes import util
+
+
+def main() -> None:
+    """Mashed needs win xp otherwise cars may fall through the ground"""
+    """https://www.pcgamingwiki.com/wiki/Mashed#Jumping_Bug_Fix"""
+    util.protontricks('winxp')
+
+    """Hide the launcher"""
+    util.append_argument('-VS0 -CS0')


### PR DESCRIPTION
This PR adds fixes for mashed. 
It will set wine to wine xp mode since this prevents that cars will fall through the ground in some stages. And it adds some launch args that will hide the launcher. 