### PR TITLE
Make protonfixes self-contained

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ DIST  ?= dist
 
 OBJDIR := $(shell realpath $(BUILD))
 DSTDIR := $(shell realpath $(DIST))
-TARGET_DIR := $(DSTDIR)/protonfixes
+TARGET_DIR := $(DSTDIR)
 
 BASEDIR       := /files
 i386_LIBDIR    = $(BASEDIR)/lib/i386-linux-gnu

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ protonfixes-install: protonfixes
 	cp         *.py         $(TARGET_DIR)
 	mkdir   -p              $(TARGET_DIR)$(BASEDIR)/bin
 	cp         winetricks   $(TARGET_DIR)$(BASEDIR)/bin
+	cp         winetricks   $(TARGET_DIR)
 	cp         umu-database.csv   $(TARGET_DIR)
 	rm $(TARGET_DIR)/protonfixes_test.py
 

--- a/Makefile
+++ b/Makefile
@@ -116,8 +116,7 @@ unzip-install: unzip-dist
 $(OBJDIR)/.build-python-xlib-dist: | $(OBJDIR)
 	$(info :: Building python-xlib )
 	cd subprojects/python-xlib && \
-	dpkg-source --before-build . && \
-	dh_auto_build -O--buildsystem=pybuild
+	python setup.py build
 	touch $(@)
 
 .PHONY: python-xlib-dist
@@ -126,10 +125,10 @@ python-xlib-dist: $(OBJDIR)/.build-python-xlib-dist
 
 python-xlib-install: python-xlib-dist
 	$(info :: Installing python-xlib )
-	mkdir -p $(INSTALL_DIR)/_vendor && \
-	cd subprojects/python-xlib && \
-	dh_auto_install -O--buildsystem=pybuild && \
-	find debian/tmp -type d -name Xlib | xargs -I {} mv {} $(INSTALL_DIR)/_vendor; \
+	mkdir $(INSTALL_DIR)/_vendor && \
+	cd subprojects/python-xlib && mkdir dist && \
+	python setup.py install --root=dist --optimize=1 --skip-build && \
+	find dist -type d -name Xlib | xargs -I {} mv {} $(INSTALL_DIR)/_vendor; \
 
 $(OBJDIR):
 	@mkdir -p $(@)

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,13 @@
-OBJDIR      := builddir
-PREFIX      ?= /files
-LIBDIR       = $(PREFIX)/lib/x86_64-linux-gnu
-DESTDIR     ?=
-INSTALL_DIR ?= $(shell pwd)/dist/protonfixes
+BUILD ?= build
+DIST  ?= dist
+
+OBJDIR := $(shell realpath $(BUILD))
+DSTDIR := $(shell realpath $(DIST))
+TARGET_DIR := $(DSTDIR)/protonfixes
+
+BASEDIR       := /files
+i386_LIBDIR    = $(BASEDIR)/lib/i386-linux-gnu
+x86_64_LIBDIR  = $(BASEDIR)/lib/x86_64-linux-gnu
 
 .PHONY: all
 
@@ -21,14 +26,14 @@ install: protonfixes-install cabextract-install libmspack-install unzip-install 
 
 protonfixes-install: protonfixes
 	$(info :: Installing protonfixes )
-	install -d              $(INSTALL_DIR)
-	cp      -r gamefixes-*  $(INSTALL_DIR)
-	cp      -r verbs        $(INSTALL_DIR)
-	cp         *.py         $(INSTALL_DIR)
-	mkdir   -p              $(INSTALL_DIR)/files/bin
-	cp         winetricks   $(INSTALL_DIR)/files/bin
-	cp         umu-database.csv   $(INSTALL_DIR)
-	rm $(INSTALL_DIR)/protonfixes_test.py
+	install -d              $(TARGET_DIR)
+	cp      -r gamefixes-*  $(TARGET_DIR)
+	cp      -r verbs        $(TARGET_DIR)
+	cp         *.py         $(TARGET_DIR)
+	mkdir   -p              $(TARGET_DIR)$(BASEDIR)/bin
+	cp         winetricks   $(TARGET_DIR)$(BASEDIR)/bin
+	cp         umu-database.csv   $(TARGET_DIR)
+	rm $(TARGET_DIR)/protonfixes_test.py
 
 #
 # libmspack and cabextract
@@ -45,7 +50,7 @@ $(OBJDIR)/.build-cabextract-dist: | $(OBJDIR)/libmspack
 	$(info :: Building cabextract )
 	cd $(OBJDIR)/libmspack/cabextract && \
 	autoreconf -fiv -I /usr/share/gettext/m4/ && \
-	./configure --prefix=$(PREFIX) --libdir=$(LIBDIR) && \
+	./configure --prefix=$(BASEDIR) --libdir=$(x86_64_LIBDIR) && \
 	make
 	touch $(@)
 
@@ -56,8 +61,8 @@ cabextract-dist: $(OBJDIR)/.build-cabextract-dist
 cabextract-install: cabextract-dist
 	$(info :: Installing cabextract )
 	cd $(OBJDIR)/libmspack/cabextract && \
-	make DESTDIR=$(INSTALL_DIR) install
-	rm -r $(INSTALL_DIR)/files/share
+	make DESTDIR=$(TARGET_DIR) install
+	rm -r $(TARGET_DIR)$(BASEDIR)/share
 
 #
 # libmspack
@@ -67,7 +72,7 @@ $(OBJDIR)/.build-libmspack-dist: | $(OBJDIR)/libmspack
 	$(info :: Building libmspack )
 	cd $(OBJDIR)/libmspack/libmspack && \
 	autoreconf -vfi && \
-	./configure --prefix=/files --libdir=/files/lib/x86_64-linux-gnu --disable-static && \
+	./configure --prefix=$(BASEDIR) --libdir=$(x86_64_LIBDIR) --disable-static && \
 	sed -i -e 's/ -shared / -Wl,-O1,--as-needed\0/g' libtool && \
 	make
 	touch $(@)
@@ -79,10 +84,10 @@ libmspack-dist: $(OBJDIR)/.build-libmspack-dist
 libmspack-install: libmspack-dist
 	$(info :: Installing libmspack )
 	cd $(OBJDIR)/libmspack/libmspack && \
-	make DESTDIR=$(INSTALL_DIR) install
-	rm -r $(INSTALL_DIR)/files/include
-	rm -r $(INSTALL_DIR)/files/lib/x86_64-linux-gnu/pkgconfig
-	rm    $(INSTALL_DIR)/files/lib/x86_64-linux-gnu/libmspack.la
+	make DESTDIR=$(TARGET_DIR) install
+	rm -r $(TARGET_DIR)$(BASEDIR)/include
+	rm -r $(TARGET_DIR)$(BASEDIR)/lib/x86_64-linux-gnu/pkgconfig
+	rm    $(TARGET_DIR)$(BASEDIR)/lib/x86_64-linux-gnu/libmspack.la
 
 #
 # unzip
@@ -102,7 +107,7 @@ $(OBJDIR)/.build-unzip-dist: | $(OBJDIR)
 	rsync -arx --delete subprojects/unzip $(OBJDIR)
 	cd $(OBJDIR)/unzip && \
 	$(foreach pch, $(UNZIP_PATCHES),patch -Np1 -i debian/patches/$(pch) &&) \
-	make -f unix/Makefile D_USE_BZ2=-DUSE_BZIP2 L_BZ2=-lbz2 LF2="$(LDFLAGS)" CF="$(CFLAGS) -I. $(DEFINES)" unzips
+	make -f unix/Makefile prefix=$(BASEDIR) D_USE_BZ2=-DUSE_BZIP2 L_BZ2=-lbz2 LF2="$(LDFLAGS)" CF="$(CFLAGS) -I. $(DEFINES)" unzips
 	touch $(@)
 
 .PHONY: unzip-dist
@@ -112,9 +117,9 @@ unzip-dist: $(OBJDIR)/.build-unzip-dist
 unzip-install: unzip-dist
 	$(info :: Installing unzip )
 	cd $(OBJDIR)/unzip && \
-	make -f unix/Makefile prefix=$(INSTALL_DIR)/files install
+	make -f unix/Makefile prefix=$(TARGET_DIR)$(BASEDIR) install
 	# Post install
-	rm -r $(INSTALL_DIR)/files/man
+	rm -r $(TARGET_DIR)$(BASEDIR)/man
 
 #
 # python-xlib
@@ -133,10 +138,10 @@ python-xlib-dist: $(OBJDIR)/.build-python-xlib-dist
 
 python-xlib-install: python-xlib-dist
 	$(info :: Installing python-xlib )
-	mkdir $(INSTALL_DIR)/_vendor
+	mkdir $(TARGET_DIR)/_vendor
 	cd $(OBJDIR)/python-xlib && mkdir dist && \
 	python setup.py install --root=dist --optimize=1 --skip-build && \
-	find dist -type d -name Xlib | xargs -I {} mv {} $(INSTALL_DIR)/_vendor; \
+	find dist -type d -name Xlib | xargs -I {} mv {} $(TARGET_DIR)/_vendor;
 
 $(OBJDIR):
 	@mkdir -p $(@)

--- a/__init__.py
+++ b/__init__.py
@@ -44,11 +44,13 @@ def check_iscriptevaluator() -> bool:
 
 
 def setup(env: dict, bin_path_var: str, lib_path_var: str, func: Callable[[dict, str, str, str], None]) -> None:
+    """Setup PATH and LD_LIBRARY_PATH to include protonfixes's binary and library paths"""
     func(env, bin_path_var, bin_dir, ':')
     func(env, lib_path_var, f'{x86_64_lib_dir}:{i386_lib_dir}', ':')
 
 
 def execute() -> None:
+    """Execute protonfixes"""
     if check_iscriptevaluator():
         log.debug('Skipping fix execution. We are running "iscriptevaluator.exe".')
     elif not check_conditions():

--- a/__init__.py
+++ b/__init__.py
@@ -3,6 +3,7 @@
 import os
 import sys
 import traceback
+from typing import Callable
 
 from . import fix
 from .logger import log
@@ -11,6 +12,10 @@ sys.path.insert(
     0,
     f'{os.path.dirname(os.path.realpath(__file__))}/_vendor',  # noqa: PTH120
 )
+
+bin_dir: str = f'{os.path.dirname(os.path.realpath(__file__))}/files/bin'
+i386_lib_dir: str = f'{os.path.dirname(os.path.realpath(__file__))}/files/lib/i386-linux-gnu'
+x86_64_lib_dir: str = f'{os.path.dirname(os.path.realpath(__file__))}/files/lib/x86_64-linux-gnu'
 
 
 def check_conditions() -> bool:
@@ -38,15 +43,24 @@ def check_iscriptevaluator() -> bool:
     return len(sys.argv) >= 3 and 'iscriptevaluator.exe' in sys.argv[2]
 
 
-if check_iscriptevaluator():
-    log.debug('Skipping fix execution. We are running "iscriptevaluator.exe".')
-elif not check_conditions():
-    log.warn('Skipping fix execution. We are probably running an unit test.')
-else:
-    try:
-        fix.main()
+def setup(env: dict, bin_path_var: str, lib_path_var: str, func: Callable[[dict, str, str, str], None]) -> None:
+    func(env, bin_path_var, bin_dir, ':')
+    func(env, lib_path_var, f'{x86_64_lib_dir}:{i386_lib_dir}', ':')
 
-    # Catch any exceptions and print a traceback
-    except Exception:
-        sys.stderr.write('ProtonFixes ' + traceback.format_exc())
-        sys.stderr.flush()
+
+def execute() -> None:
+    if check_iscriptevaluator():
+        log.debug('Skipping fix execution. We are running "iscriptevaluator.exe".')
+    elif not check_conditions():
+        log.warn('Skipping fix execution. We are probably running an unit test.')
+    else:
+        try:
+            fix.main()
+
+        # Catch any exceptions and print a traceback
+        except Exception:
+            sys.stderr.write('ProtonFixes ' + traceback.format_exc())
+            sys.stderr.flush()
+
+
+__all__ = ["setup", "execute"]

--- a/util.py
+++ b/util.py
@@ -321,7 +321,7 @@ def protontricks(verb: str) -> bool:
         env['WINETRICKS_LATEST_VERSION_CHECK'] = 'disabled'
         env['LD_PRELOAD'] = ''
 
-        winetricks_bin = os.path.abspath(__file__).replace('util.py', 'winetricks')
+        winetricks_bin = 'winetricks'
         winetricks_cmd = [winetricks_bin, '--unattended'] + verb.split(' ')
         if verb == 'gui':
             winetricks_cmd = [winetricks_bin, '--unattended']


### PR DESCRIPTION
I am opening this early as a request for comments.

The goal of this PR is to make protonfixes self-contained and improve including them is Proton's build process. It also makes the WOW64 transition easier. It tries to achieve that by not installing binary dependencies in Proton's PATH and LD_LIBRARY_PATH, but rather prepend its own paths into Proton's session environment.

To achieve this, instead of running `protonfixes` when the module is loaded, two new functions are introduced `protonfixes.setup()` and `protonfixes.execute()` to be used as follows
```python
    import protonfixes
    protonfixes.setup(g_session.env, "PATH", ld_path_var, prepend_to_env_str)

    # Allow umu clients to run winetricks verbs and be the frontend for them
    if (
        g_session.env.get("UMU_ID")
        and g_session.env.get("EXE", "").endswith("winetricks")
        and g_session.env.get("PROTON_VERB") == "waitforexitandrun"
    ):
        wt_verbs = " ".join(sys.argv[2:][2:])
        g_session.env["WINE"] = g_proton.wine_bin
        g_session.env["WINELOADER"] = g_proton.wine_bin
        g_session.env["WINESERVER"] = g_proton.wineserver_bin
        g_session.env["WINETRICKS_LATEST_VERSION_CHECK"] = "disabled"
        g_session.env["LD_PRELOAD"] = ""

        log(f"Running winetricks verbs in prefix: {wt_verbs}")
        rc = subprocess.run(sys.argv[2:], check=False, env=g_session.env).returncode

        sys.exit(rc)

    protonfixes.execute()
```
(umu winetricks handling for context)

The binary dependencies are now installed under `protonfixes/files`, mirroring Proton's folder structure, although the name is just a preference. This doesn't include vendored dependencies for now, although that can also be looked into.
```
dist/protonfixes/files/
dist/protonfixes/files/bin
dist/protonfixes/files/bin/winetricks
dist/protonfixes/files/bin/cabextract
dist/protonfixes/files/bin/unzip
dist/protonfixes/files/bin/funzip
dist/protonfixes/files/bin/unzipsfx
dist/protonfixes/files/bin/zipgrep
dist/protonfixes/files/bin/zipinfo
dist/protonfixes/files/lib
dist/protonfixes/files/lib/x86_64-linux-gnu
dist/protonfixes/files/lib/x86_64-linux-gnu/libmspack.so.0.1.0
dist/protonfixes/files/lib/x86_64-linux-gnu/libmspack.so.0
dist/protonfixes/files/lib/x86_64-linux-gnu/libmspack.so
```

This also makes it simpler to include `protonfixes` in Proton's makefile, removing the need for for custom steps such as
```Makefile
    cp $(PROTONFIXES_TARGET)/cabextract $(REDIST_DIR)/files/bin/
    ln -s ../bin/cabextract $(REDIST_DIR)/files/bin-wow64/cabextract
    cp $(PROTONFIXES_TARGET)/unzip $(REDIST_DIR)/files/bin/
    ln -s ../bin/unzip $(REDIST_DIR)/files/bin-wow64/unzip
    cp -a $(PROTONFIXES_TARGET)/libmspack.so $(REDIST_DIR)/files/lib/$(x86_64-unix_LIBDIR)
    cp -a $(PROTONFIXES_TARGET)/libmspack.so.0 $(REDIST_DIR)/files/lib/$(x86_64-unix_LIBDIR)
    cp $(PROTONFIXES_TARGET)/libmspack.so.0.1.0 $(REDIST_DIR)/files/lib/$(x86_64-unix_LIBDIR)
```
and should make it possible to do out-of-source builds for `protonfixes` later, following Proton's makefile paradigm to help with rebuilds.
