### PR TITLE
Install `quartz` to allow Tree of Savior to work on GE 10

### DIFF
--- a/gamefixes-steam/372000.py
+++ b/gamefixes-steam/372000.py
@@ -6,3 +6,5 @@ from protonfixes import util
 def main() -> None:
     """https://forum.treeofsavior.com/t/linux-the-graphic-card-does-not-support-directx11-13ep/418073/13"""
     util.protontricks('d3dcompiler_47')
+    # Installing Quartz allows the game to work on GE 10-1
+    util.protontricks('quartz')


### PR DESCRIPTION
Looks like the game is having trouble with startup crashes on Proton versions later than Proton 8, but it apparently works with Quartz installed on GE 10-1.

https://github.com/ValveSoftware/Proton/issues/2224#issuecomment-2888792837