### PR TITLE
patch_libcuda: Fix patched library name and use a temporary directory instead of .cache

### DIFF
--- a/util.py
+++ b/util.py
@@ -512,8 +512,6 @@ def patch_libcuda() -> bool:
 
     Returns true if the library was patched correctly. Otherwise returns false
     """
-    config.path.cache_dir.mkdir(parents=True, exist_ok=True)
-
     try:
         # Use shutil.which to find ldconfig binary
         ldconfig_path = shutil.which('ldconfig')

--- a/util.py
+++ b/util.py
@@ -586,10 +586,19 @@ def patch_libcuda() -> bool:
             return False
 
         log.info(f'Patched libcuda.so saved to: {patched_library}')
-        protonmain.g_session.env['LD_LIBRARY_PATH'] = (
-            f'{patched_library.parent}:{protonmain.g_session.env["LD_LIBRARY_PATH"]}'
-        )
 
+        # Set LD_LIBRARY_PATH and LD_PRELOAD to include the directory (or absolute path) of the patched library
+        current_ld_path = protonmain.g_session.env.get("LD_LIBRARY_PATH")
+        protonmain.g_session.env["LD_LIBRARY_PATH"] = (
+            f"{patched_library.parent}:{current_ld_path}" if current_ld_path else str(patched_library)
+        )
+        log.info(f'LD_LIBRARY_PATH updated to {protonmain.g_session.env.get("LD_LIBRARY_PATH")}')
+
+        current_ld_preload = protonmain.g_session.env.get("LD_PRELOAD")
+        protonmain.g_session.env["LD_PRELOAD"] = (
+            f"{patched_library}:{current_ld_preload}" if current_ld_preload else str(patched_library)
+        )
+        log.info(f'LD_PRELOAD updated to {protonmain.g_session.env.get("LD_PRELOAD")}')
         return True
 
     except Exception as e:

--- a/util.py
+++ b/util.py
@@ -555,7 +555,7 @@ def patch_libcuda() -> bool:
 
         log.info(f'Found 64-bit libcuda.so at: {libcuda_path}')
 
-        patched_library = config.path.cache_dir / 'libcuda.patched.so'
+        patched_library = config.path.cache_dir / os.path.basename(libcuda_path)
         try:
             binary_data = Path(libcuda_path).read_bytes()
         except OSError as e:

--- a/util.py
+++ b/util.py
@@ -554,8 +554,8 @@ def patch_libcuda() -> bool:
             return False
 
         log.info(f'Found 64-bit libcuda.so at: {libcuda_path}')
-
-        patched_library = config.path.cache_dir / os.path.basename(libcuda_path)
+        from tempfile import mkdtemp
+        patched_library = Path(mkdtemp()) / os.path.basename(libcuda_path)
         try:
             binary_data = Path(libcuda_path).read_bytes()
         except OSError as e:

--- a/util.py
+++ b/util.py
@@ -588,16 +588,12 @@ def patch_libcuda() -> bool:
         log.info(f'Patched libcuda.so saved to: {patched_library}')
 
         # Set LD_LIBRARY_PATH and LD_PRELOAD to include the directory (or absolute path) of the patched library
-        current_ld_path = protonmain.g_session.env.get("LD_LIBRARY_PATH")
-        protonmain.g_session.env["LD_LIBRARY_PATH"] = (
-            f"{patched_library.parent}:{current_ld_path}" if current_ld_path else str(patched_library)
-        )
+        ld_paths = [str(patched_library.parent), protonmain.g_session.env.get("LD_LIBRARY_PATH")]  
+        protonmain.g_session.env["LD_LIBRARY_PATH"] = ":".join(filter(None, ld_paths))  
         log.info(f'LD_LIBRARY_PATH updated to {protonmain.g_session.env.get("LD_LIBRARY_PATH")}')
 
-        current_ld_preload = protonmain.g_session.env.get("LD_PRELOAD")
-        protonmain.g_session.env["LD_PRELOAD"] = (
-            f"{patched_library}:{current_ld_preload}" if current_ld_preload else str(patched_library)
-        )
+        ld_paths = [str(patched_library), protonmain.g_session.env.get("LD_PRELOAD")]  
+        protonmain.g_session.env["LD_PRELOAD"] = ":".join(filter(None, ld_paths))
         log.info(f'LD_PRELOAD updated to {protonmain.g_session.env.get("LD_PRELOAD")}')
         return True
 


### PR DESCRIPTION
Making sure we use the right name should ensure that this library is loaded correctly as it's path is added to the beginning of LD_LIBRARY_PATH. 

Additionally using a tempdir makes sense as the cache that is currently being used isn't really a cache, it's just being used as a temporary directory anyways.

Let me know if you have any additional changes in mind.