### PR TITLE
Remove no longer useful Dauntless fix, due to game shutting down

### DIFF
--- a/gamefixes-steam/331370.py
+++ b/gamefixes-steam/331370.py
@@ -1,8 +1,0 @@
-"""Game fix for Dauntless"""
-
-from protonfixes import util
-
-
-def main() -> None:
-    """Game needs SteamDeck=1 for EAC to work."""
-    util.set_environment('SteamDeck', '1')


### PR DESCRIPTION
The game has now been shut down following the disastrous update.