### PR TITLE
Add fixes for Persona 4 Arena Ultimax

### DIFF
--- a/gamefixes-steam/1602010.py
+++ b/gamefixes-steam/1602010.py
@@ -1,0 +1,10 @@
+"""Persona 4 Arena Ultimax
+Missing voices/sounds in cutscenes
+Requires disabling the gstreamer protonaudioconverterbin plugin to get full audio in cutscenes.
+"""
+
+from protonfixes import util
+
+
+def main() -> None:
+    util.disable_protonmediaconverter()


### PR DESCRIPTION
Currently audio does not play during cutscenes in Persona 4 Arena Ultimax. ProtonDB users noticed disabling protonaudioconverterbin via environment arg fixes it, and I noticed Persona 5 Strikers (1382330) has the same problem, but it has the fixes applied in this repo. I've basically copied 1382330.py to 1602010.py and changed the game title in the comment.

Tested with GE-Proton10-4.