### PR TITLE
gamefixes: replace vcrun2019 with vcrun2022 to avoid changing Windows version to win7

### DIFF
--- a/gamefixes-steam/1151640.py
+++ b/gamefixes-steam/1151640.py
@@ -5,6 +5,6 @@ from protonfixes import util
 
 def main() -> None:
     # C++ runtime is not provided in the manifest
-    util.protontricks('vcrun2019')
+    util.protontricks('vcrun2022')
     # Set SteamGameId so that non-steam versions can pick up steam-specific fixes in proton's wine code
     util.set_environment('SteamGameId', '1151640')

--- a/gamefixes-steam/1239520.py
+++ b/gamefixes-steam/1239520.py
@@ -5,4 +5,4 @@ from protonfixes import util
 
 def main() -> None:
     # Replace launcher with game exe in proton arguments
-    util.protontricks('vcrun2019')
+    util.protontricks('vcrun2022')

--- a/gamefixes-steam/1240440.py
+++ b/gamefixes-steam/1240440.py
@@ -4,4 +4,4 @@ from protonfixes import util
 
 
 def main() -> None:
-    util.protontricks('vcrun2019')
+    util.protontricks('vcrun2022')

--- a/gamefixes-steam/1259970.py
+++ b/gamefixes-steam/1259970.py
@@ -5,6 +5,6 @@ from protonfixes import util
 
 def main() -> None:
     # Replace launcher with game exe in proton arguments
-    util.protontricks('vcrun2019')
+    util.protontricks('vcrun2022')
     util.protontricks('allfonts')
     util.protontricks('dotnet462')

--- a/gamefixes-steam/1293830.py
+++ b/gamefixes-steam/1293830.py
@@ -5,4 +5,4 @@ from protonfixes import util
 
 def main() -> None:
     # Replace launcher with game exe in proton arguments
-    util.protontricks('vcrun2019')
+    util.protontricks('vcrun2022')

--- a/gamefixes-steam/1532190.py
+++ b/gamefixes-steam/1532190.py
@@ -5,6 +5,6 @@ from protonfixes import util
 
 def main() -> None:
     # Requires vcrun2019 to launch
-    util.protontricks('vcrun2019')
+    util.protontricks('vcrun2022')
     util.protontricks('d3dcompiler_47')
     util.protontricks('msxml3')

--- a/gamefixes-steam/1613450.py
+++ b/gamefixes-steam/1613450.py
@@ -5,6 +5,6 @@ from protonfixes import util
 
 def main() -> None:
     # Requires vcrun2019 to launch
-    util.protontricks('vcrun2019')
+    util.protontricks('vcrun2022')
     util.protontricks('d3dcompiler_47')
     util.protontricks('msxml3')

--- a/gamefixes-steam/1695791.py
+++ b/gamefixes-steam/1695791.py
@@ -5,6 +5,6 @@ from protonfixes import util
 
 def main() -> None:
     # Requires vcrun2019 to launch
-    util.protontricks('vcrun2019')
+    util.protontricks('vcrun2022')
     util.protontricks('d3dcompiler_47')
     util.protontricks('msxml3')

--- a/gamefixes-steam/1695794.py
+++ b/gamefixes-steam/1695794.py
@@ -5,6 +5,6 @@ from protonfixes import util
 
 def main() -> None:
     # Requires vcrun2019 to launch
-    util.protontricks('vcrun2019')
+    util.protontricks('vcrun2022')
     util.protontricks('d3dcompiler_47')
     util.protontricks('msxml3')

--- a/gamefixes-steam/1715130.py
+++ b/gamefixes-steam/1715130.py
@@ -5,5 +5,5 @@ from protonfixes import util
 
 def main() -> None:
     # Replace launcher with game exe in proton arguments
-    util.protontricks('vcrun2019')
+    util.protontricks('vcrun2022')
     util.protontricks('d3dcompiler_43')

--- a/gamefixes-steam/601510.py
+++ b/gamefixes-steam/601510.py
@@ -5,4 +5,4 @@ from protonfixes import util
 
 def main() -> None:
     # Replace launcher with game exe in proton arguments
-    util.protontricks('vcrun2019')
+    util.protontricks('vcrun2022')

--- a/gamefixes-steam/627270.py
+++ b/gamefixes-steam/627270.py
@@ -5,4 +5,4 @@ from protonfixes import util
 
 def main() -> None:
     # Requires vcrun2019 to launch
-    util.protontricks('vcrun2019')
+    util.protontricks('vcrun2022')

--- a/gamefixes-steam/813780.py
+++ b/gamefixes-steam/813780.py
@@ -5,4 +5,4 @@ from protonfixes import util
 
 def main() -> None:
     # Requires vcrun2019 to launch
-    util.protontricks('vcrun2019')
+    util.protontricks('vcrun2022')

--- a/gamefixes-steam/976310.py
+++ b/gamefixes-steam/976310.py
@@ -5,4 +5,4 @@ from protonfixes import util
 
 def main() -> None:
     # Requires vcrun2019 to launch
-    util.protontricks('vcrun2019')
+    util.protontricks('vcrun2022')

--- a/gamefixes-steam/976730.py
+++ b/gamefixes-steam/976730.py
@@ -5,4 +5,4 @@ from protonfixes import util
 
 def main() -> None:
     # Requires vcrun2019 to launch
-    util.protontricks('vcrun2019')
+    util.protontricks('vcrun2022')

--- a/gamefixes-steam/997070.py
+++ b/gamefixes-steam/997070.py
@@ -5,5 +5,5 @@ from protonfixes import util
 
 def main() -> None:
     # Requires vcrun2019 to launch
-    util.protontricks('vcrun2019')
+    util.protontricks('vcrun2022')
     util.protontricks('d3dcompiler_47')

--- a/gamefixes-zoomplatform/umu-240200.py
+++ b/gamefixes-zoomplatform/umu-240200.py
@@ -5,4 +5,4 @@ from protonfixes import util
 
 def main() -> None:
     util.winedll_override('d3d8', util.OverrideOrder.NATIVE_BUILTIN)
-    util.protontricks('vcrun2019')
+    util.protontricks('vcrun2022')


### PR DESCRIPTION
`vcrun219` and `vcrun2022` should be equal for most intends and purposes, so replace the former with the latter to avoid winetricks setting the Windows version in the prefix to Windows 7.

I have not tested any of the games. For that reason I left the original comments mentioning vcrun2019 untouched.
