### PR TITLE
Workaround to fix Sifu freezing

### DIFF
--- a/gamefixes-steam/2138710.py
+++ b/gamefixes-steam/2138710.py
@@ -1,8 +1,8 @@
 """Sifu"""
 
-from protonfixes import util, BasePath
+from protonfixes import util
 
 
 def main() -> None:
     """Stops the game from freezing."""
-    util.set_ini_options('[/script/engine.renderersettings]\nr.CreateShadersOnLoad=1', 'Sifu/Saved/Config/WindowsClient/Engine.ini', base_path = BasePath.APPDATA_LOCAL)
+    util.set_ini_options('[/script/engine.renderersettings]\nr.CreateShadersOnLoad=1', 'Sifu/Saved/Config/WindowsClient/Engine.ini', base_path = util.BasePath.APPDATA_LOCAL)

--- a/gamefixes-steam/2138710.py
+++ b/gamefixes-steam/2138710.py
@@ -1,0 +1,8 @@
+"""Sifu"""
+
+from protonfixes import util, BasePath
+
+
+def main() -> None:
+    """Stops the game from freezing."""
+    util.set_ini_options('[/script/engine.renderersettings]\nr.CreateShadersOnLoad=1', 'Sifu/Saved/Config/WindowsClient/Engine.ini', base_path = BasePath.APPDATA_LOCAL)

--- a/util.py
+++ b/util.py
@@ -47,6 +47,7 @@ class BasePath(Enum):
 
     USER = 'user'
     GAME = 'game'
+    APPDATA_LOCAL = 'appdata_local'
 
 
 class OverrideOrder(Enum):
@@ -745,6 +746,8 @@ def _get_config_full_path(cfile: StrPath, base_path: BasePath) -> Optional[str]:
         )
     elif base_path == BasePath.GAME:
         cfg_path = os.path.join(get_game_install_path(), cfile)
+    elif base_path == BasePath.APPDATA_LOCAL:
+        cfg_path = os.path.join(protonprefix(), 'drive_c/users/steamuser/AppData/Local', cfile)
     else:
         cfg_path = cfile
     cfg_path = _get_case_insensitive_name(str(cfg_path))


### PR DESCRIPTION
Apparently, the game's long-standing freezing problems under Proton are fixable through editing a config file, but the file is in the `AppData/Local` folder in the prefix, so I also had to update `_get_config_full_path` and `BasePath` because that directory is not reachable with either of the two options available, and may also come in handy in case there are other games out there that put their config files in the `AppData` folder.

https://github.com/ValveSoftware/Proton/issues/6657#issuecomment-3037914449