### PR TITLE
chore: remove 73170 steam fix

### DIFF
--- a/gamefixes-steam/73170.py
+++ b/gamefixes-steam/73170.py
@@ -1,9 +1,0 @@
-"""Game fix for Darkest Hour: A Hearts of Iron Game"""
-
-from protonfixes import util
-
-
-def main() -> None:
-    """Set virtual desktop"""
-    # https://github.com/ValveSoftware/Proton/issues/3338
-    util.protontricks('vd=1280x720')


### PR DESCRIPTION
Darkest Hour: A Hearts of Iron Game appears to be working correctly without the need of a fix with the following Proton versions:

- Proton 9.0.4
- Proton 10.0-1 (beta)
- Proton Experimental

Additionally, the fix here is now not working properly and actively hampers the game experience (issues with game resolution). I imagine something changed with the handling of the resolution in Proton/Wine, and/or virtual desktops.

So, it seems like the best thing to do here is to remove the fix as the game now works fine without it, and using the fix negatively impacts the experience.