### PR TITLE
Link Guild Wars 2 Steam protonfix to EGS version

### DIFF
--- a/gamefixes-egs/umu-1284210.py
+++ b/gamefixes-egs/umu-1284210.py
@@ -1,0 +1,1 @@
+../gamefixes-steam/1284210.py


### PR DESCRIPTION
Links EGS Guild Wars 2 to the Steam protonfix