### PR TITLE
Add multiplayer fix for WH40k: Dawn of War - Definitive Edition

### DIFF
--- a/gamefixes-steam/3556750.py
+++ b/gamefixes-steam/3556750.py
@@ -1,0 +1,8 @@
+"""Warhammer 40,000: Dawn of War - Definitive Edition"""
+
+from protonfixes import util
+
+
+def main() -> None:
+    # Needed to fix multiplayer desync
+    util.protontricks('ucrtbase2019')


### PR DESCRIPTION
This should fix the multiplayer desync issue.