### PR TITLE
Restore sound for ONE PIECE: PIRATE WARRIORS 4

### DIFF
--- a/gamefixes-steam/1089090.py
+++ b/gamefixes-steam/1089090.py
@@ -1,0 +1,10 @@
+"""ONE PIECE: PIRATE WARRIORS 4
+Missing voices/sounds in cutscenes
+Requires disabling the gstreamer protonaudioconverterbin plugin to get full audio in cutscenes.
+"""
+
+from protonfixes import util
+
+
+def main() -> None:
+    util.disable_protonmediaconverter()


### PR DESCRIPTION
Restores missing cut scene voices. Works with GE-Proton9-27. Latest GE-Proton10-12 has issues playing cut scenes (loads a color test screen), so I am not sure if this patch is helpful until that regression is resolved in future proton versions.