### PR TITLE
Add d3dx9 for Two Worlds: Epic Edition

### DIFF
--- a/gamefixes-steam/1930.py
+++ b/gamefixes-steam/1930.py
@@ -7,3 +7,4 @@ from protonfixes import util
 
 def main() -> None:
     util.protontricks('xact')
+    util.protontricks('d3dx9')


### PR DESCRIPTION
The game without this dependency has a bug where the image starts to flicker as if it were a rainbow. The fix is ​​documented in protondb.