### PR TITLE
STORY OF SEASONS: Pioneers of Olive Town boot fix.

### DIFF
--- a/gamefixes-steam/1392960.py
+++ b/gamefixes-steam/1392960.py
@@ -1,0 +1,9 @@
+"""Game fix for STORY OF SEASONS: Pioneers of Olive Town"""
+
+from protonfixes import util
+
+
+def main() -> None:
+    #Wont boot without them, sadly doesn't fix DLC not actually loading in game, casefolding issue?
+    util.protontricks('d3dcompiler_43')
+    util.protontricks('d3dcompiler_47')


### PR DESCRIPTION
Gets the game booting, though it doesn't fix the non working DLC, some sorta casefolding issue probably?