### PR TITLE
Fix Battle Engine Aquila overlapping sound

### DIFF
--- a/gamefixes-steam/1346400.py
+++ b/gamefixes-steam/1346400.py
@@ -4,5 +4,5 @@ from protonfixes import util
 
 
 def main() -> None:
-    """Game needs dsound dlls to fix looping and overlapping sound in menus and ingame"""
+    """Game needs DirectSound dlls to fix looping and overlapping sound in menus and ingame"""
     util.protontricks('dsound')


### PR DESCRIPTION
[Battle Engine Aquila](https://store.steampowered.com/app/1346400/Battle_Engine_Aquila/)(1346400) seems to need this one winetricks command to override the DirectSound dlls and fix the sound and music. 

Without it as soon as you launch the game the music and sound starts looping multiple times and overlapping over each other. 

After some light playtesting i could detect no other breakages introduced, at least for my hardware. 
Tested with GE-Proton 10-17