### PR TITLE
Fix videos not playing in Blue Protocol: Star Resonance

### DIFF
--- a/gamefixes-steam/3681810.py
+++ b/gamefixes-steam/3681810.py
@@ -1,0 +1,8 @@
+"""Game fix for Blue Protocol: Star Resonance"""
+
+from protonfixes import util
+
+
+def main() -> None:
+    """Setting prefix to Windows 7 is needed for videos to play correctly"""
+    util.protontricks('win7')


### PR DESCRIPTION
Blue Protocol: Star Resonance ([3681810](https://store.steampowered.com/app/3681810/Blue_Protocol_Star_Resonance/)) shows a black screen on all videos unless the Wineprefix is set to Windows 7.

This probably doesn't have to do with codecs but rather with something in the game itself, which is surprisingly fixed by just changing the Windows version.

- GE-Proton10-17 on a clean prefix (Windows version set to Win10):

<img width="1920" height="1080" alt="Screenshot_20251009_204041" src="https://github.com/user-attachments/assets/7d90c25b-268d-4e4e-a7f4-ab9a5d34eef2" />

---

- GE-Proton10-17 with Windows version set to Win7

<img width="1920" height="1080" alt="Screenshot_20251009_203714" src="https://github.com/user-attachments/assets/b963641d-62c4-4dad-b6dc-29adbe3f2dad" />

