### PR TITLE
Remove fixes setting `SteamGameId`

### DIFF
--- a/gamefixes-ea/umu-1222690.py
+++ b/gamefixes-ea/umu-1222690.py
@@ -1,1 +1,0 @@
-../gamefixes-steam/1222690.py

--- a/gamefixes-ea/umu-2009100.py
+++ b/gamefixes-ea/umu-2009100.py
@@ -1,1 +1,0 @@
-../gamefixes-steam/2009100.py

--- a/gamefixes-egs/umu-2009100.py
+++ b/gamefixes-egs/umu-2009100.py
@@ -1,8 +1,0 @@
-"""Game fix for Immortals of Aveum"""
-
-from protonfixes import util
-
-
-def main() -> None:
-    # Set SteamGameId so that non-steam versions can pick up steam-specific fixes in proton's wine code
-    util.set_environment('SteamGameId', '2009100')

--- a/gamefixes-humble/umu-2009100.py
+++ b/gamefixes-humble/umu-2009100.py
@@ -1,8 +1,0 @@
-"""Game fix for Immortals of Aveum"""
-
-from protonfixes import util
-
-
-def main() -> None:
-    # Set SteamGameId so that non-steam versions can pick up steam-specific fixes in proton's wine code
-    util.set_environment('SteamGameId', '2009100')

--- a/gamefixes-steam/1151640.py
+++ b/gamefixes-steam/1151640.py
@@ -6,5 +6,3 @@ from protonfixes import util
 def main() -> None:
     # C++ runtime is not provided in the manifest
     util.protontricks('vcrun2022')
-    # Set SteamGameId so that non-steam versions can pick up steam-specific fixes in proton's wine code
-    util.set_environment('SteamGameId', '1151640')

--- a/gamefixes-steam/1174180.py
+++ b/gamefixes-steam/1174180.py
@@ -6,5 +6,3 @@ from protonfixes import util
 def main() -> None:
     """Sometimes game will not launch if -fullscreen -vulkan is not specified"""
     util.append_argument('-fullscreen -vulkan')
-    # Set SteamGameId so that non-steam versions can pick up steam-specific fixes in proton's wine code
-    util.set_environment('SteamGameId', '1174180')

--- a/gamefixes-steam/1222690.py
+++ b/gamefixes-steam/1222690.py
@@ -1,9 +1,0 @@
-"""Game fix for Dragon Age Inquisition"""
-
-from protonfixes import util
-
-
-def main() -> None:
-    """Has Xinput patch in proton-wine"""
-    # Set SteamGameId so that non-steam versions can pick up steam-specific fixes in proton's wine code
-    util.set_environment('SteamGameId', '1222690')

--- a/gamefixes-steam/2009100.py
+++ b/gamefixes-steam/2009100.py
@@ -1,8 +1,0 @@
-"""Game fix for Immortals of Aveum"""
-
-from protonfixes import util
-
-
-def main() -> None:
-    # Set SteamGameId so that non-steam versions can pick up steam-specific fixes in proton's wine code
-    util.set_environment('SteamGameId', '2009100')

--- a/gamefixes-steam/582660.py
+++ b/gamefixes-steam/582660.py
@@ -9,7 +9,5 @@ def main() -> None:
     # Fixes the startup process.
     if 'NOSTEAM' in os.environ:
         util.replace_command('--steam', '')
-    # Needed for settings archive
-    util.set_environment('SteamGameId', '582660')
     # Needed for Launcher
     util.set_environment('WINE_DISABLE_KERNEL_WRITEWATCH', '1')


### PR DESCRIPTION
`SteamGameId` is already set automatically by umu-launcher based on the game ID ([here](<https://github.com/Open-Wine-Components/umu-launcher/blob/23ec7c75bedd282b88105ab30df78ddcfe40d414/umu/umu_run.py#L220-L221>)), so these fixes don't do anything anymore