### PR TITLE
Add a fix for Persona 5 Strikers that works around crashes on Intel 12th gen and newer CPUs

### DIFF
--- a/gamefixes-steam/1382330.py
+++ b/gamefixes-steam/1382330.py
@@ -2,10 +2,76 @@
 Missing voices/sounds in cutscenes
 Requires disabling the gstreamer protonaudioconverterbin plugin to get full audio in cutscenes.
 fixed by Swish in Protondb
+
+Also, on Intel Alder Lake and newer CPUs, the game may crash on startup due to a conflict with Denuvo.
+This can be fixed by limiting the game to only use Performance cores (P-cores).
 """
 
 from protonfixes import util
-
+import os
 
 def main() -> None:
     util.disable_protonmediaconverter()
+
+    p_cores = get_intel_p_cores()
+    if p_cores is not None:
+        util.set_environment("taskset", f"-c {p_cores[0]}-{p_cores[1]}")
+
+def get_intel_p_cores():
+    # Maps Intel CPU generation numbers to their respective names
+    INTEL_GEN_MODEL_CODES = (
+        151, # 12th Gen (Alder Lake)
+        183, # 13th Gen (Raptor Lake)
+        190, # 14th Gen (Raptor Lake Refresh)
+        201, # 15th Gen (Arrow Lake, early)
+    )
+
+    # Check if the CPU is Intel and is an appropriate generation
+    with open("/proc/cpuinfo") as f:
+        cpu_info = f.readlines()
+        is_intel = False
+
+        for line in cpu_info:
+            if line.startswith("vendor_id") and "GenuineIntel" in line:
+                is_intel = True
+                break
+
+        # Return None if not Intel CPU
+        if not is_intel:
+            return None
+
+        # Set is_intel back to false in case the generation test fails
+        is_intel = False
+        for line in cpu_info:
+            if line.startswith("model"):
+                for code in INTEL_GEN_MODEL_CODES:
+                    if f": {code}" in line:
+                        is_intel = True
+                        break
+            if is_intel:
+                break
+
+        # Return None CPU is not in supported generations
+        if not is_intel:
+            return None
+
+        # If the test succeeds, we proceed to return a list of P-cores in the CPU
+        # Start by checking the number of CPU cores
+        cpu_count = os.cpu_count()
+        if cpu_count is None:
+            return None
+
+        p_cores = []
+        for core in range(1, cpu_count, 2):
+            try:
+                with open(f"/sys/devices/system/cpu/cpu{core}/topology/core_cpus_list") as core_file:
+                    core_type = core_file.read().strip()
+                    thread_list = core_type.split("-")
+
+                    if len(thread_list) == 2:
+                        p_cores.extend([int(thread_list[0]), int(thread_list[1])])
+            except FileNotFoundError:
+                # If the core_type file doesn't exist, we can't determine core type
+                return None
+
+        return (p_cores[0], p_cores[-1])


### PR DESCRIPTION
As documented [here](https://www.pcgamingwiki.com/wiki/Persona_5_Strikers), Persona 5 Strikers will crash on Intel 12th gen and newer CPUs due to E-Cores conflicting with its DRM, Denuvo.

So I created a patch that limits the game to using P-Cores on Intel CPUs of Alder Lake generation or newer. I tried to implement it using `WINE_CPU_TOPOLOGY`, but the game exhibits the same behavior with that. So instead, I set the game to use taskset for this and it allows the game to not crash during the initial loading screen.

The game still freezes after that due to missing video codecs, but when I tested this in GE-Proton, it worked on my laptop using an Intel Core i9 14900HX.