### PR TITLE
Add fix for Asphalt 8

### DIFF
--- a/gamefixes-egs/umu-7580986b33344aeb8fd733caa7457a72.py
+++ b/gamefixes-egs/umu-7580986b33344aeb8fd733caa7457a72.py
@@ -1,0 +1,7 @@
+"""Fix for Asphalt 8"""
+
+from protonfixes import util
+
+
+def main() -> None:
+    util.protontricks('d3dcompiler_47')


### PR DESCRIPTION
Needs `d3dcompiler_47`, otherwise it'll have broken graphics

In case you're testing this, make sure to delete your Wineprefix between tests. The game caches the compile result in `drive_c/users/steamuser/AppData/Local/Gameloft/Asphalt8/<epic ID>/temp`