### PR TITLE
Fix CEF issues in Duet Night Abyss

### DIFF
--- a/gamefixes-egs/umu-3950020.py
+++ b/gamefixes-egs/umu-3950020.py
@@ -1,0 +1,8 @@
+"""Game fix for Duet Night Abyss"""
+
+from protonfixes import util
+
+
+def main() -> None:
+    """Installing dotnet48 fixes CEF issues (e.g. in-game news not loading)"""
+    util.protontricks('dotnet48')


### PR DESCRIPTION
Database PR: https://github.com/Open-Wine-Components/umu-database/pull/110

Duet Night Abyss' in-game news tabs (CEF) doesn't load unless `dotnet48` is installed.

Fresh prefix on GE-Proton10-25:

<img width="1132" height="647" alt="image" src="https://github.com/user-attachments/assets/b1b6f871-3e64-42c8-a360-3865fd270329" />

Prefix with `dotnet48` installed:

<img width="1132" height="647" alt="image" src="https://github.com/user-attachments/assets/5558e59f-1d7e-4eb6-b8e6-387cbc70fdf2" />

---

Game is planning to come to Steam too ([3950020](https://store.steampowered.com/app/3950020/Duet_Night_Abyss/)) but no ETA yet, will add a Protonfix for it as well if the same issue occurs.