### PR TITLE
Add fix for Not For Broadcast

### DIFF
--- a/gamefixes-steam/1147550.py
+++ b/gamefixes-steam/1147550.py
@@ -1,0 +1,9 @@
+"""Game fix for Not For Broadcast"""
+
+from protonfixes import util
+
+
+def main() -> None:
+    # Force using winegstreamer instead of winedmo for video playback
+    # Fixes video/game freezing and crashing
+    util.set_environment('PROTON_MEDIA_USE_GST', '1')


### PR DESCRIPTION
This game is heavily reliant on video playback, so much so that it doesn't work with default Proton. Proton-GE is needed.

There are some beta branches of the game that aim to fix video playback that some users experience. I've tried only one of them, but it didn't help me.

Then I remembered about the GST media thing and I tried the normal version (without beta branches selected) and in comparison to winedmo backend it seems all video/game freezing and crashing is fixed.

https://store.steampowered.com/app/1147550/Not_For_Broadcast/

This fix was tested by completing the first chapter of the game successfully. Without this fix, the game crashes/freezes entirely after less than 5 minutes of gameplay (even in the main menu).

Tested with GE-Proton10-25.

Database PR: https://github.com/Open-Wine-Components/umu-database/pull/115