### PR TITLE
Add fix for Not For Broadcast on EGS/GOG

### DIFF
--- a/gamefixes-egs/umu-1147550.py
+++ b/gamefixes-egs/umu-1147550.py
@@ -1,0 +1,1 @@
+../gamefixes-steam/1147550.py

--- a/gamefixes-gog/umu-1147550.py
+++ b/gamefixes-gog/umu-1147550.py
@@ -1,0 +1,1 @@
+../gamefixes-steam/1147550.py


### PR DESCRIPTION
Follow up to commit 42204d1321464c8d1dcdf08abb888cb702d7fef5. 

- https://www.gog.com/en/game/not_for_broadcast
- https://store.epicgames.com/en-US/p/not-for-broadcast-7e523f
