### PR TITLE
Fixed minor grammar mistake in log message in __init__.py: an unit test -> a unit test

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -108,7 +108,7 @@ def execute() -> None:
     if check_iscriptevaluator():
         log.debug('Skipping fix execution. We are running "iscriptevaluator.exe".')
     elif not check_conditions():
-        log.warn('Skipping fix execution. We are probably running an unit test.')
+        log.warn('Skipping fix execution. We are probably running a unit test.')
     else:
         try:
             fix.main()


### PR DESCRIPTION
This PR corrects a small grammar mistake in a log message in __init__.py.

Original: "an unit test"
Correct: "a unit test"

No functional behavior has been changed.