### PR TITLE
Fix Zenless Zone Zero crashing at startup.

### DIFF
--- a/gamefixes-umu/umu-zenlesszonezero.py
+++ b/gamefixes-umu/umu-zenlesszonezero.py
@@ -6,3 +6,7 @@ from protonfixes import util
 def main() -> None:
     """Needs gamedrive fix to detect proper install space"""
     util.set_game_drive(True)
+    """By default umu runs games on start.exe outside steam.
+    However, Zenless's AC needs the game to be run from steam.exe to run on Linux.
+    """
+    util.set_environment('UMU_USE_STEAM', '1')


### PR DESCRIPTION
Since latest update, Zenless also implemented the same steam.exe check as Genshin (see https://github.com/Open-Wine-Components/umu-protonfixes/commit/9097d50ff45ccdf0291fbe7e39dbec0ac42f3684 and https://github.com/Open-Wine-Components/umu-protonfixes/commit/b429abd7203e34ac7cd2996331991ee5cf3071d0).