### PR TITLE
proton: check directory access for mapped drives

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -99,7 +99,7 @@ def setup_mount_drives(func: Callable[[str, str, str], None]) -> None:
         }
 
         for directory in drive_map.keys():
-            if os.path.exists(directory) and not _is_directory_empty(directory):
+            if os.access(directory, os.R_OK) and not _is_directory_empty(directory):
                 func('gamedrive', drive_map[directory], directory)
 
 


### PR DESCRIPTION
Check if a directory is readable before attempting to map it.

Fixes this error (using umu-run):
Traceback (most recent call last):
  File ".../proton", line 1930, in <module>
    g_session.init_session(sys.argv[1] != "runinprefix")
  File ".../proton", line 1822, in init_session
    g_compatdata.setup_prefix()
  File ".../proton", line 1204, in setup_prefix
    setup_game_dir_drive()
  File ".../proton", line 419, in setup_game_dir_drive
    if os.path.exists(directory) and not is_directory_empty(directory):
  File ".../proton", line 407, in is_directory_empty
    return not any(os.scandir(dir_path))
PermissionError: [Errno 13] Permission denied: '/media'

Like when running in a sandbox:
$ firejail --disable-mnt
$ ls /mnt
ls: cannot open directory '/mnt': Permission denied