### PR TITLE
Add fix for SOMA

### DIFF
--- a/gamefixes-steam/282140.py
+++ b/gamefixes-steam/282140.py
@@ -1,0 +1,8 @@
+"""Game fix for SOMA"""
+
+import os
+from protonfixes import util
+
+
+def main() -> None:
+    util.disable_ntsync()


### PR DESCRIPTION
SOMA doesn't seem to work with NTSync enabled (hangs on the startup loading screen).

Couple questions:
- Do I need to do something with the database file? There is an entry for SOMA, but it's for the "amazon" store, though it does use the Steam store id. Also would like to enable the same fix for other stores, and standalone mode.
- Is there anything that could be done to keep ntsync enabled? If you have a suggestion on further debugging, I'd love to hear it.