### PR TITLE
Add fixes for Escape from Tarkov on Steam

### DIFF
--- a/gamefixes-steam/3932890.py
+++ b/gamefixes-steam/3932890.py
@@ -1,0 +1,84 @@
+"""Escape From Tarkov
+Install BattlEye Service - does not permit online play
+"""
+
+import os
+import glob
+import shutil
+from protonfixes import util
+
+def main() -> None:
+    util.set_environment('PROTON_USE_XALIA', '0')
+    util.protontricks('dotnet48')
+    util.protontricks('vcrun2022')
+    util.protontricks('dotnetdesktop6')
+    util.protontricks('dotnetdesktop8')
+
+    game_dir = glob.escape(util.get_game_install_path())
+
+    battleye_source = os.path.join(
+        game_dir,
+        'build/BattlEye/',
+    )
+
+    battleye_install = os.path.join(
+        util.protonprefix(),
+        'drive_c/Program Files (x86)/Common Files/BattlEye/',
+    )
+
+    if not os.path.exists(battleye_install):
+        # Setup BattlEye Service for the game to run
+        # This is only to get past the launcher and does not enable online play
+
+        util.regedit_add(
+            'HKLM\\System\\CurrentControlSet\\Services\\BEService',
+            'DisplayName',
+            'REG_SZ',
+            'BattlEye Service',
+        )
+        util.regedit_add(
+            'HKLM\\System\\CurrentControlSet\\Services\\BEService',
+            'ErrorControl',
+            'REG_DWORD',
+            '1',
+        )
+        util.regedit_add(
+            'HKLM\\System\\CurrentControlSet\\Services\\BEService',
+            'ObjectName',
+            'REG_SZ',
+            'LocalSystem',
+        )
+        util.regedit_add(
+            'HKLM\\System\\CurrentControlSet\\Services\\BEService',
+            'ImagePath',
+            'REG_SZ',
+            'C:\\Program Files (x86)\\Common Files\\BattlEye\\BEService_x64.exe',
+        )
+        util.regedit_add(
+            'HKLM\\System\\CurrentControlSet\\Services\\BEService',
+            'PreshutdownTimeout',
+            'REG_DWORD',
+            '180000',
+        )
+        util.regedit_add(
+            'HKLM\\System\\CurrentControlSet\\Services\\BEService',
+            'Start',
+            'REG_DWORD',
+            '2',
+        )
+
+        util.regedit_add(
+            'HKLM\\System\\CurrentControlSet\\Services\\BEService',
+            'Type',
+            'REG_DWORD',
+            '16',
+        )
+
+        util.regedit_add(
+            'HKLM\\System\\CurrentControlSet\\Services\\BEService',
+            'WOW64',
+            'REG_DWORD',
+            '1',
+        )
+
+        shutil.copytree(battleye_source, battleye_install, dirs_exist_ok=True)


### PR DESCRIPTION
needed fixes were found by the community mainly the Tarkov Penguins Discord and [MadByteDE/SPT-Linux-Guide](https://github.com/MadByteDE/SPT-Linux-Guide)

during the dotnet48 installation there is an annoying pop-up thats already tracked #454
<img width="347" height="167" alt="image" src="https://github.com/user-attachments/assets/8d15e15e-d14d-45a6-abeb-404cff73cdf0" />

logic here is mostly a copy of this helper script I wrote
<https://gist.github.com/Jan200101/e107eb83f712d84c9ac21b174f522853>
could clean up the regedit section more if desired