### PR TITLE
install battleye runtime for Tarkov

### DIFF
--- a/gamefixes-steam/3932890.py
+++ b/gamefixes-steam/3932890.py
@@ -8,6 +8,7 @@ import shutil
 from protonfixes import util
 
 def main() -> None:
+    util.install_battleye_runtime()
     util.set_environment('PROTON_USE_XALIA', '0')
     util.protontricks('dotnet48')
     util.protontricks('vcrun2022')


### PR DESCRIPTION
follow-up to #465, the Tarkov Launcher checks for the service but the game actually communicates with the runtime.
I missed this because on my Desktop install I already had the battleye runtime installed but on a fresh install it wasn't, adding this makes it work