### PR TITLE
properly extend steam libpaths

### DIFF
--- a/steamhelper.py
+++ b/steamhelper.py
@@ -67,7 +67,7 @@ def _get_steam_libraries_path() -> list:
                 os.path.expanduser(steampath), 'steamapps', 'libraryfolders.vdf'
             )
             if os.path.exists(libfile):
-                libpaths.append(_find_regex_groups(libfile, REGEX_LIB, 'path'))
+                libpaths.extend(_find_regex_groups(libfile, REGEX_LIB, 'path'))
                 break
     return libpaths
 


### PR DESCRIPTION
anything calling `_get_steam_libraries_path` expects it to return `list[str]` but in reality it returns `list[list[str]]`.

This PR squashes the list back down, fixes install_app not working properly.