### PR TITLE
adapt Tarkov fixes for outside of steam

### DIFF
--- a/gamefixes-umu/umu-3932890.py
+++ b/gamefixes-umu/umu-3932890.py
@@ -1,0 +1,1 @@
+../gamefixes-steam/3932890.py


### PR DESCRIPTION
- add a file to check if service was already configured and configures it if its missing
    - there are setups where the BattlEye service installs but the service is only configured to start manually so it never runs and the Launcher complains. 
- checks if service files were already installed
- looks for BattlEye files from the Steam version and BsgLauncher version
- add umu symlink to steam fix

I added logging similar to the wintricks stuff to the service configuration so that the user is aware of whats happening
```
ProtonFixes[97958] INFO: Using global defaults for UNKNOWN (3932890)
ProtonFixes[97958] INFO: Using local protonfix for UNKNOWN (3932890)
ProtonFixes[97958] INFO: Checking if winetricks "dotnet48" is installed
ProtonFixes[97958] INFO: Checking if winetricks "vcrun2022" is installed
ProtonFixes[97958] INFO: Checking if winetricks "dotnetdesktop6" is installed
ProtonFixes[97958] INFO: Checking if winetricks "dotnetdesktop8" is installed
ProtonFixes[97958] INFO: Checking if BattlEye Service is installed
```

Tested this locally using umu-launcher but I still needed to set PROTON_BATTLEYE_RUNTIME, wouldn't be an issue on Lutris and co.