### PR TITLE
minimize tarkov fixes

### DIFF
--- a/gamefixes-steam/3932890.py
+++ b/gamefixes-steam/3932890.py
@@ -10,6 +10,7 @@ from protonfixes import util
 def main() -> None:
     util.install_battleye_runtime()
     util.protontricks('dotnet48')
+    util.append_argument("--disable-software-rasterizer")
 
     game_dir = glob.escape(util.get_game_install_path())
 


### PR DESCRIPTION
following a discussion on discord I've minimized the extra dependencies needed to what is just required to run the game, additionally `--disable-software-rasterizer` prevents the launcher from flickering heavily.