### PR TITLE
umu-starcitizen gamefixes

### DIFF
--- a/gamefixes-umu/umu-starcitizen.py
+++ b/gamefixes-umu/umu-starcitizen.py
@@ -21,8 +21,6 @@ def main() -> None:
     # RSI Launcher depends on powershell
     util.protontricks('powershell')
 
-    # RSI Launcher animation
-    util.winedll_override('libglesv2', util.OverrideOrder.BUILTIN)
-
-    # SC's shipped EAC Installer fails with ntsync
-    util.disable_ntsync()
+    # Prevent RSI Launcher install and update from hanging indefinitely
+    util.winedll_override('dxwebsetup.exe', util.OverrideOrder.DISABLED)
+    util.winedll_override('dotNetFx45_Full_setup.exe', util.OverrideOrder.DISABLED)


### PR DESCRIPTION
- Remove the libglesv2 override
  - The launcher animation lag no longer present on systems surveyed. The override has also conflicted with winewayland mode via PROTON_ENABLE_WAYLAND=1 by preventing the launcher window from displaying
- Remove ntsync override
  - The noted EAC conflict has not been observed for some time by players that have ntsync enabled
- Disable dxwebsetup.exe and dotNetFx45_Full_setup.exe
  - Prevent an infrequent but perpetual hang when the RSI  Launcher is installing or updating. Some star citizen linux community tools [LUG Helper](https://github.com/starcitizen-lug/lug-helper/blob/main/lug-helper.sh#L2205) and [rsi launcher flatpak](https://github.com/mactan-sc/rsilauncher/blob/main/scripts/rsi-run.sh#L42) each disable these 