### PR TITLE
Update fix for Full Metal Daemon Muramasa

### DIFF
--- a/gamefixes-gog/umu-1209310984.py
+++ b/gamefixes-gog/umu-1209310984.py
@@ -5,4 +5,4 @@ from protonfixes import util
 
 def main() -> None:
     util.disable_protonmediaconverter()
-    util.winedll_override('wmvdecod', util.OverrideOrder.DISABLED)
+    util.set_environment('PROTON_MEDIA_USE_GST', '1')


### PR DESCRIPTION
### Description

Attempting to play the videos from the game's Extra menu with the current fix results in the videos being skipped. At the time, this was due to the fix disabling the wmvdecod DLL, which was needed to get in-game media to render otherwise placeholders would be displayed. Since then both GE-Proton and Proton (bleeding-edge) has improved a bit. On the other hand, without applying the fix, the videos would play but without any audio. To ensure that both the videos listed in the game's Extra menu with audio and in-game media renders properly, use the gstreamer-based backend.

### Expected behavior

For all in-game media and the movies in the Extra menu to play with audio.

### Steps to reproduce

1. Launch the game.
2. From the Title menu, navigate to the Extra menu. Note, the Extra menu is only unlocked after completing the game.
3. Play the videos displayed on the left hand side.

### Logging, screenshots, or anything else

Log with new umu-1209310984.py: 

https://gist.github.com/R1kaB3rN/df6db035b4e10b3beebc46c2f909c277

Video with new umu-1209310984.py:

https://github.com/user-attachments/assets/2e2d02a5-d58d-4186-a9aa-0211fa7f17d7

### System Information

OS: SteamOS (3.7.19)
Proton: GE-Proton10-26