### PR TITLE
Install `dotnet48` for PAIcom to prevent crashing

### DIFF
--- a/gamefixes-steam/1876280.py
+++ b/gamefixes-steam/1876280.py
@@ -1,0 +1,8 @@
+"""PAIcom"""
+
+from protonfixes import util
+
+
+def main() -> None:
+    """Crashes unless dotnet48 is installed."""
+    util.protontricks('dotnet48')


### PR DESCRIPTION
https://github.com/ValveSoftware/Proton/issues/9016#issuecomment-3679742062
https://www.protondb.com/app/1876280?device=any

There is no Winetricks verb named `net48`.