### PR TITLE
Add broken textures fix for Legendary

### DIFF
--- a/gamefixes-steam/16730.py
+++ b/gamefixes-steam/16730.py
@@ -1,0 +1,8 @@
+"""Game fix for Legendary"""
+
+from protonfixes import util
+
+
+def main() -> None:
+    """Fixes broken textures issue"""
+    util.protontricks('winxp')


### PR DESCRIPTION
Adds a fix for Legendary on Steam. By default, the game loads with broken textures making many objects looks flat and like putty. Switching the prefix to winxp fixes it.

Many thanks.