### PR TITLE
add game drive env var for Duet Night Abyss

### DIFF
--- a/gamefixes-steam/3950020.py
+++ b/gamefixes-steam/3950020.py
@@ -1,9 +1,20 @@
 """Game fix for Duet Night Abyss"""
 
+import os
+
 from protonfixes import util
+
+
+def _is_env_one(name: str) -> bool:
+    return os.environ.get(name, '') == '1'
 
 
 def main() -> None:
     """CEF tries to use dcomp by default which only has stubs, this triggers a fallback to a different backend"""
     util.winedll_override('dcomp', util.OverrideOrder.DISABLED)
+
     util.set_environment('PROTON_SET_GAME_DRIVE', '1')
+
+    """News tab freezes upon spawn on winewayland, disabling libGLES fixes it """
+    if _is_env_one('PROTON_USE_WAYLAND') or _is_env_one('PROTON_ENABLE_WAYLAND'):
+        util.winedll_override('libGLESv2', util.OverrideOrder.DISABLED)


### PR DESCRIPTION
Duet Night Abyss will not let you log in unless the game directory is symlinked to prefix. 
This just set the proton env var to do this for us so it is not needed within steam. 
Also disables libGLESv2 for wayland as it causes freezes on the news tab in the game. 