### PR TITLE
upscalers: use mirror for the more recent upscaler dlls

### DIFF
--- a/upscalers.py
+++ b/upscalers.py
@@ -291,7 +291,7 @@ def __download_file(url: str, dst: Path, *, checksum: Union[str, None] = None) -
     request = urllib.request.Request(
         url,
         headers={
-            'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; WOW64; rv:40.0) Gecko/20100101 Firefox/40.0'
+            'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; WOW64; rv:40.0) Gecko/20100101 Proton/10.0'
         },
     )
     try:


### PR DESCRIPTION
Mirror a few of the more recent files in https://loathingkernel.github.io/proton-upscalers to reduce the traffic from our side to dlss-swapper's infra. This also allowed me to compress the files with lzma to further reduce their size. The GH pages store is temporary until I find a better hosting service for a complete mirror (around 3GB of storage for the complete archive presently).
