### PR TITLE
chore: cleanup some fsr4 logic

### DIFF
--- a/upscalers.py
+++ b/upscalers.py
@@ -164,13 +164,13 @@ def __get_fsr4_dlls(version: str = 'default') -> dict:
         return cached_file.exists()
 
     if version == 'default' or version not in __fsr4_dlls.keys():
-        version = '4.0.3'
+        version = next(reversed(__fsr4_dlls))
 
     item = __fsr4_dlls[version]
-    if not (__dll_download_exists(item['download_url']) or _cached_file_exists(item)):
+    if not (_cached_file_exists(item) or __dll_download_exists(item['download_url'])):
         for key in sorted(__fsr4_dlls.keys(), reverse=True):
             item = __fsr4_dlls[key]
-            if __dll_download_exists(item['download_url']) or _cached_file_exists(item):
+            if _cached_file_exists(item) or __dll_download_exists(item['download_url']):
                 version = key
                 break
 


### PR DESCRIPTION
The existing `or` command to check for a cached FSR 4 file was causing unnecessary network requests by checking the URLs before checking the cached files (because or statements resolve from left to right). This reverses that logic to check cached files first and avoids unnecessary network requests when launching games.

This also changes the default version to be the last entry in the dict. Up til now, this has been a hardcoded value that needs updated to prefer new releases. If the preference is to have the default version hardcoded as it was, then this change can be dropped.