### PR TITLE
Add fix for The Elder Scrolls Online (ESO)

### DIFF
--- a/gamefixes-umu/umu-306130.py
+++ b/gamefixes-umu/umu-306130.py
@@ -1,0 +1,8 @@
+"""Game fix for The Elder Scrolls Online"""
+
+from protonfixes import util
+
+
+def main() -> None:
+    """Installs Microsoft Edge WebView2 Runtime required for the game launcher"""
+    util.protontricks('webview2')


### PR DESCRIPTION
## Summary
Adds a gamefix for The Elder Scrolls Online (umu-306130).

## Changes
- Adds `gamefixes-umu/umu-306130.py` which installs Microsoft Edge WebView2 Runtime (using recently added winetricks verb: [webview2](https://github.com/Winetricks/winetricks/pull/2467))

## Why
The game launcher requires WebView2 Runtime to function properly. Without this fix, the launcher fails to start.

Reference: https://www.protondb.com/app/306130#nui5kb6WdP