### PR TITLE
add fix for Gray Zone Warfare EAC hash errors after subseqent launches

### DIFF
--- a/gamefixes-steam/2479810.py
+++ b/gamefixes-steam/2479810.py
@@ -1,0 +1,34 @@
+"""Game fix for Gray Zone Warfare
+
+Sets specific cache files to read-only to prevent the game from modifying them
+after first launch, which would invalidate Easy Anti-Cheat hashes.
+"""
+
+import stat
+from pathlib import Path
+
+from protonfixes import util
+from protonfixes.logger import log
+
+
+def main() -> None:
+    """Set EAC-validated cache files to read-only"""
+    game_dir = Path(util.get_game_install_path())
+    cache_dir = game_dir / "GZW/Content/SKALLA/PrebuildWorldData/World/cache"
+
+    files = [
+        "0xb9af63cee2e43b6c_0x3cb3b3354fb31606.dat",
+        "0xaf497c273f87b6e4_0x7a22fc105639587d.dat",
+    ]
+
+    for filename in files:
+        filepath = cache_dir / filename
+        if filepath.is_file():
+            # Remove write permission for owner, group, and others
+            current_mode = filepath.stat().st_mode
+            readonly_mode = current_mode & ~(stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH)
+            if current_mode != readonly_mode:
+                log.info(f'Setting "{filepath.name}" to read-only.')
+                filepath.chmod(readonly_mode)
+        else:
+            log.info(f'Cache file "{filepath.name}" not found, skipping.')


### PR DESCRIPTION
For some reason when you launch the game under Proton these two cache files are either changed or regenerated in some way which causes EAC to boot you from the game after subsequent launches. 

`0xaf497c273f87b6e4_0x7a22fc105639587d.dat`
`0xb9af63cee2e43b6c_0x3cb3b3354fb31606.dat`

The best way to get around this is to set those two files as read only so the game won't invalidate it's own EAC hashes.

I have manually applied this fix for the last few patches and the filenames haven't changed.

Obviously this is a symptom of some syscall not behaving as expected or being implemented incorrectly on the Wine side of things but this should resolve the issue until that is either looked into or resolved.
