### PR TITLE
Add GOG gamefix for Rebel Galaxy Outlaw (umu-910830)

### DIFF
--- a/gamefixes-gog/umu-910830.py
+++ b/gamefixes-gog/umu-910830.py
@@ -1,0 +1,11 @@
+"""Game fix for Rebel Galaxy Outlaw (GOG)"""
+
+from protonfixes import util
+
+
+def main() -> None:
+    """Installs mfc42"""
+    # GOG version has the same issue as Steam:
+    # ScnLib.dll requires MFC42u.DLL which is not provided by Proton
+    # https://github.com/ValveSoftware/Proton/issues/4216
+    util.protontricks('mfc42')


### PR DESCRIPTION
## Summary

- Adds `mfc42` winetricks fix for the **GOG version** of Rebel Galaxy Outlaw
- Mirrors the existing Steam fix (`gamefixes-steam/910830.py`) which addresses the same issue

## Problem

When launching the GOG version via Heroic Game Launcher, the game launcher (Launcher.exe) opens, but clicking "Start" silently fails. The game executable (`RebelGalaxy.exe`) depends on `ScnLib.dll` (a bundled screen recording library), which requires `MFC42u.DLL`. This DLL is not provided by Proton or the GOG redistributables.

Log output:
```
err:module:import_dll Library MFC42u.DLL (which is needed by "...\ScnLib.DLLs\ScnLib.dll") not found
err:module:loader_init Importing dlls for "...\RebelGalaxy.exe" failed, status c0000135
```

## Fix

Install `mfc42` via protontricks, same as the existing Steam fix.

## Testing

- **Distro:** Bazzite 43 (Fedora Atomic / Kinoite)
- **GPU:** NVIDIA RTX 3060 Ti (driver 595.58.3)
- **Proton:** GE-Proton10-30 (via Heroic Game Launcher)
- **Heroic:** 2.20.1 (Flatpak)

## Reference

- Valve Proton issue: https://github.com/ValveSoftware/Proton/issues/4216
- Existing Steam fix: `gamefixes-steam/910830.py`