### PR TITLE
Create fix for S&box Editor

### DIFF
--- a/gamefixes-steam/2129370.py
+++ b/gamefixes-steam/2129370.py
@@ -1,8 +1,8 @@
-"""Fix for S\&box Editor"""
+r"""Fix for S\&box Editor"""
 
 from protonfixes import util
 
 
 def main() -> None:
-    """Installs  dotnetdesktop10 for the S\&box editor"""
+    r"""Installs  dotnetdesktop10 for the S\&box editor"""
     util.protontricks('dotnetdesktop10')

--- a/gamefixes-steam/2129370.py
+++ b/gamefixes-steam/2129370.py
@@ -1,0 +1,8 @@
+"""Fix for S\&box Editor"""
+
+from protonfixes import util
+
+
+def main() -> None:
+    """Installs  dotnetdesktop10 for the S\&box editor"""
+    util.protontricks('dotnetdesktop10')


### PR DESCRIPTION
Fixes S&box Editor launching by installing `dotnetdesktop10` to the prefix.