### PR TITLE
add fix for GOG release of Quake II (Original)

### DIFF
--- a/gamefixes-gog/umu-2320.py
+++ b/gamefixes-gog/umu-2320.py
@@ -1,0 +1,10 @@
+"""Game fix for Quake II (Original)"""
+
+from protonfixes import util
+
+
+def main() -> None:
+    # Fix crash at startup when using OpenGL
+    util.set_environment('PROTON_OLD_GL_STRING', '1')
+	# Fix in-game music not playing
+    util.set_environment('WINEDLLOVERRIDES', 'winmm=n,b')

--- a/gamefixes-gog/umu-2320.py
+++ b/gamefixes-gog/umu-2320.py
@@ -7,4 +7,4 @@ def main() -> None:
     # Fix crash at startup when using OpenGL
     util.set_environment('PROTON_OLD_GL_STRING', '1')
 	# Fix in-game music not playing
-    util.set_environment('WINEDLLOVERRIDES', 'winmm=n,b')
+    util.winedll_override('winmm', util.OverrideOrder.NATIVE_BUILTIN)

--- a/gamefixes-gog/umu-2320.py
+++ b/gamefixes-gog/umu-2320.py
@@ -5,6 +5,7 @@ from protonfixes import util
 
 def main() -> None:
     # Fix crash at startup when using OpenGL
-    util.set_environment('PROTON_OLD_GL_STRING', '1')
+    util.set_environment('MESA_EXTENSION_MAX_YEAR', '2003')
+    util.set_environment('__GL_ExtensionStringVersion', '17700')
 	# Fix in-game music not playing
     util.winedll_override('winmm', util.OverrideOrder.NATIVE_BUILTIN)


### PR DESCRIPTION
Adds fixes for a crash at startup and for in game music not playing. The Steam version already has the OpenGL fix applied. The Steam version doesn't include the in-game music but the GOG version does. It needs a dll override to make this work.

Depends on https://github.com/Open-Wine-Components/umu-database/pull/141
