### PR TITLE
protonfixes: do not export `PROTON_DLL_COPY=*` on module import

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -9,6 +9,7 @@ from . import fix
 from .logger import log
 from .upscalers import setup_upscalers
 from .utilities import (
+    check_verb_requirements,
     setup_frame_rate,
     setup_local_shader_cache,
     setup_mount_drives,
@@ -65,6 +66,7 @@ def execute_early() -> None:
     elif not check_conditions():
         log.warn('Skipping fix execution. We are probably running a unit test.')
     else:
+        check_verb_requirements()
         fix.early()
 
 

--- a/__init__.py
+++ b/__init__.py
@@ -33,10 +33,6 @@ aarch64_lib_dir: str = (
 )
 
 
-# This is needed for protonfixes
-os.environ['PROTON_DLL_COPY'] = '*'
-
-
 def check_conditions() -> bool:
     """Determine, if the actual game was executed and protonfixes isn't deactivated.
 

--- a/gamefixes-steam/1112400.py
+++ b/gamefixes-steam/1112400.py
@@ -1,6 +1,11 @@
 """Game fix for Project Torque"""
+import os
 
 from protonfixes import util
+
+
+def early() -> None:
+    os.environ['PROTON_DLL_COPY'] = '*'
 
 
 def main() -> None:

--- a/gamefixes-steam/1259970.py
+++ b/gamefixes-steam/1259970.py
@@ -1,6 +1,11 @@
 """Game fix for Pes 2021"""
+import os
 
 from protonfixes import util
+
+
+def early() -> None:
+    os.environ['PROTON_DLL_COPY'] = '*'
 
 
 def main() -> None:

--- a/gamefixes-steam/1695793.py
+++ b/gamefixes-steam/1695793.py
@@ -2,8 +2,13 @@
 Standalone and Sapien seem to work just fine without d3dcompiler_47 and msxml3, although might be required at some deeper level. I just playtested it.
 - Oro, @orowith2os
 """
+import os
 
 from protonfixes import util
+
+
+def early() -> None:
+    os.environ['PROTON_DLL_COPY'] = '*'
 
 
 def main() -> None:

--- a/gamefixes-steam/1876280.py
+++ b/gamefixes-steam/1876280.py
@@ -1,6 +1,11 @@
 """PAIcom"""
+import os
 
 from protonfixes import util
+
+
+def early() -> None:
+    os.environ['PROTON_DLL_COPY'] = '*'
 
 
 def main() -> None:

--- a/gamefixes-steam/2129370.py
+++ b/gamefixes-steam/2129370.py
@@ -1,6 +1,11 @@
 r"""Fix for S\&box Editor"""
+import os
 
 from protonfixes import util
+
+
+def early() -> None:
+    os.environ['PROTON_DLL_COPY'] = '*'
 
 
 def main() -> None:

--- a/gamefixes-steam/23460.py
+++ b/gamefixes-steam/23460.py
@@ -6,6 +6,10 @@ Videos still don't work.
 from protonfixes import util
 
 
+def early() -> None:
+    os.environ['PROTON_DLL_COPY'] = '*'
+
+
 def main() -> None:
     util.set_environment('PROTON_NO_XALIA', '1')
     util.protontricks('dotnet35sp1')

--- a/gamefixes-steam/23460.py
+++ b/gamefixes-steam/23460.py
@@ -2,6 +2,7 @@
 Works with dotnet35sp1 only, now without needing Proton5
 Videos still don't work.
 """
+import os
 
 from protonfixes import util
 

--- a/gamefixes-steam/244210.py
+++ b/gamefixes-steam/244210.py
@@ -1,6 +1,11 @@
 """Game fix for Assetto Corsa"""
+import os
 
 from protonfixes import util
+
+
+def early() -> None:
+    os.environ['PROTON_DLL_COPY'] = '*'
 
 
 def main() -> None:

--- a/gamefixes-steam/244850.py
+++ b/gamefixes-steam/244850.py
@@ -1,6 +1,11 @@
 """Game fix for Space Engineers"""
+import os
 
 from protonfixes import util
+
+
+def early() -> None:
+    os.environ['PROTON_DLL_COPY'] = '*'
 
 
 def main() -> None:

--- a/gamefixes-steam/269330.py
+++ b/gamefixes-steam/269330.py
@@ -1,6 +1,11 @@
 """Game fix for Chronology"""
+import os
 
 from protonfixes import util
+
+
+def early() -> None:
+    os.environ['PROTON_DLL_COPY'] = '*'
 
 
 def main() -> None:

--- a/gamefixes-steam/33390.py
+++ b/gamefixes-steam/33390.py
@@ -1,6 +1,11 @@
 """Zeit²"""
+import os
 
 from protonfixes import util
+
+
+def early() -> None:
+    os.environ['PROTON_DLL_COPY'] = '*'
 
 
 def main() -> None:

--- a/gamefixes-steam/3669060.py
+++ b/gamefixes-steam/3669060.py
@@ -1,6 +1,11 @@
 """Game fix for Blade & Soul NEO"""
+import os
 
 from protonfixes import util
+
+
+def early() -> None:
+    os.environ['PROTON_DLL_COPY'] = '*'
 
 
 def main() -> None:

--- a/gamefixes-steam/3932890.py
+++ b/gamefixes-steam/3932890.py
@@ -8,6 +8,10 @@ import shutil
 from protonfixes import util
 
 
+def early() -> None:
+    os.environ['PROTON_DLL_COPY'] = '*'
+
+
 def main() -> None:
     util.install_battleye_runtime()
     util.protontricks('dotnet48')

--- a/gamefixes-umu/umu-aa2.py
+++ b/gamefixes-umu/umu-aa2.py
@@ -1,8 +1,13 @@
 """Application fix Artificial Academy 2
 Launcher game settings: Disable wine3d, enable win10fix
 """
+import os
 
 from protonfixes import util
+
+
+def early() -> None:
+    os.environ['PROTON_DLL_COPY'] = '*'
 
 
 def main() -> None:

--- a/gamefixes-umu/umu-pantheonrotf.py
+++ b/gamefixes-umu/umu-pantheonrotf.py
@@ -1,6 +1,11 @@
 """Game fix for Pantheon: Rise of the Fallen"""
+import os
 
 from protonfixes import util
+
+
+def early() -> None:
+    os.environ['PROTON_DLL_COPY'] = '*'
 
 
 def main() -> None:

--- a/gamefixes-umu/umu-pkhex.py
+++ b/gamefixes-umu/umu-pkhex.py
@@ -1,6 +1,11 @@
 """PKHeX"""
+import os
 
 from protonfixes import util
+
+
+def early() -> None:
+    os.environ['PROTON_DLL_COPY'] = '*'
 
 
 def main() -> None:

--- a/gamefixes-umu/winetricks-gui.py
+++ b/gamefixes-umu/winetricks-gui.py
@@ -1,6 +1,11 @@
 """Call Winetricks GUI"""
+import os
 
 from protonfixes import util
+
+
+def early() -> None:
+    os.environ['PROTON_DLL_COPY'] = '*'
 
 
 def main() -> None:

--- a/utilities.py
+++ b/utilities.py
@@ -8,6 +8,24 @@ from typing import Callable
 from .logger import log
 
 
+DLL_COPY_VERBS = {
+    'dotnet',
+}
+
+
+def check_verb_requirements() -> None:
+    """Check if we are installing winetricks verbs and apply env configuration"""
+    for idx, part in enumerate(sys.argv):
+        if part.endswith('winetricks'):
+            verbs = sys.argv[idx+1:]
+            break
+    else:
+        verbs = []
+
+    if verbs and any(canary in verb for verb in verbs for canary in DLL_COPY_VERBS):
+        os.environ['PROTON_DLL_COPY'] = '*'
+
+
 def winetricks(env: dict, wine_bin: str, wineserver_bin: str) -> None:
     """Handle winetricks"""
     if (


### PR DESCRIPTION
`protonfixes` exports `PROTON_DLL_COPY=*` on module import, which causes proton to copy all files from proton's default prefix instead of symlinking them. This causes the prefix to explode in size, delays startup and unnecessarily amplifies disk writes. The reason this is done though, as far back as I could find, was to allow various redist installers to work, including but likely not limited to `dotnet`.

This change removes the export from the module import scope, and instead uses an early-stage fix directive to export the environment variable only for fixes that install a version of dotnet. The scope of the files copied by `PROTON_DLL_COPY` can be reduced further at a later date.

Presently I am not aware of any other redists that require this fix, but we can expand on it later on.
