### PR TITLE
Install vcrun2022 for all itch.io titles by default

### DIFF
--- a/gamefixes-itchio/default.py
+++ b/gamefixes-itchio/default.py
@@ -1,0 +1,7 @@
+"""Setup for all itch.io games"""
+
+from protonfixes import util
+
+
+def main() -> None:
+    util.protontricks('vcrun2022')


### PR DESCRIPTION
See https://github.com/Open-Wine-Components/umu-protonfixes/pull/216 and https://github.com/Open-Wine-Components/umu-protonfixes/pull/327#discussion_r2096611856

A lot of fan games rely on vcrun2022, doesn't seem like there's any harm in installing it by default