### PR TITLE
fix: disable sha extensions for gog games

### DIFF
--- a/gamefixes-gog/default.py
+++ b/gamefixes-gog/default.py
@@ -1,0 +1,7 @@
+"""Setup for all GOG games"""
+
+from protonfixes import util
+
+
+def main() -> None:
+    util.set_environment('OPENSSL_ia32cap', ':~0x20000000')


### PR DESCRIPTION
gog often ships outdated versions of OpenSSL, that may cause crashes on some hardware with SHA extensions, especially Intel 10th gen and newer. See https://www.intel.com/content/www/us/en/developer/articles/troubleshooting/openssl-sha-crash-bug-requires-application-update.html