### PR TITLE
Fix missing zenity wait dialog in steamrt4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,7 +194,9 @@ procps-ng-install: procps-ng-dist
 # zenity-rs
 #
 
-ZENITY_RS_VER := 0.2.6
+ZENITY_RS_VER := 0.2.8
+ZENITY_RS_x86_64_SHA256 := 797bd492a8723d741d888320ab87b934b0c4571a1ff2c128963a08daa35df8c7
+ZENITY_RS_aarch64_SHA256 := c3f8a11fdc17632ffe3d5b1640a931139c2b8d86145c531e0f4db8a63ca3f2a2
 
 $(OBJDIR)/zenity-rs: | $(OBJDIR)
 	mkdir -p $(@)

--- a/__init__.py
+++ b/__init__.py
@@ -95,10 +95,10 @@ def execute() -> None:
     else:
         dialog = None
         if os.environ.get('UMU_ID', '') != 'winetricks-gui':
-            dialog = ZenityWaitDialog('Installing Game-Specific fixes, please wait...')
+            dialog = ZenityWaitDialog(os.path.join(bin_dir, 'zenity'))
         try:
             if isinstance(dialog, ZenityWaitDialog):
-                dialog.start()
+                dialog.start(text='Installing Game-Specific fixes, please wait...')
             fix.main()
 
         except Exception:

--- a/zenity.py
+++ b/zenity.py
@@ -10,7 +10,7 @@ from typing import Optional
 class ZenityWaitDialog:
     """Implements a waiting dialog using zenity"""
 
-    def __init__(self, text: str, title: str = 'ProtonFixes') -> None:
+    def __init__(self, zenity_bin: str) -> None:
         """Initialize zenity dialog
 
         :param text: the message displayed in the dialog window
@@ -19,8 +19,7 @@ class ZenityWaitDialog:
         :param title: the title of the dialog window
         :type title: str
         """
-        self._text = text
-        self._title = title
+        self._zenity = zenity_bin
         self._proc = None  # type: Optional[subprocess.Popen]
         self._stop_evt = threading.Event()
         self._thread = None  # type: Optional[threading.Thread]
@@ -35,20 +34,19 @@ class ZenityWaitDialog:
 
         return env
 
-    def _start_one(self) -> Optional[subprocess.Popen]:
+    def _start_one(self, text: str, title: str) -> Optional[subprocess.Popen]:
         env = self._make_env()
         if not env:
             return None  # no display; skip
 
         cmd = [
-            'zenity',
+            self._zenity,
             '--progress',
             '--pulsate',
             '--no-cancel',
             '--auto-close',
-            '--title=' + self._title,
-            '--text=' + self._text,
-            '--width=420',
+            '--text=' + text,
+            '--title=' + title,
         ]
 
         proc = subprocess.Popen(
@@ -61,10 +59,10 @@ class ZenityWaitDialog:
 
         return proc
 
-    def start(self) -> None:
+    def start(self, *, text: str, title: str = 'ProtonFixes') -> None:
         """Show the wait dialog"""
         try:
-            self._proc = self._start_one()
+            self._proc = self._start_one(text, title)
         except FileNotFoundError:
             self._proc = None
             return
@@ -76,7 +74,7 @@ class ZenityWaitDialog:
             while not self._stop_evt.is_set():
                 if self._proc and self._proc.poll() is not None:
                     try:
-                        self._proc = self._start_one()
+                        self._proc = self._start_one(text, title)
                     except FileNotFoundError:
                         self._proc = None
                         return

--- a/zenity.py
+++ b/zenity.py
@@ -2,10 +2,8 @@
 
 import os
 import subprocess
-import tempfile
 import threading
 import time
-from pathlib import Path
 from typing import Optional
 
 
@@ -26,7 +24,6 @@ class ZenityWaitDialog:
         self._proc = None  # type: Optional[subprocess.Popen]
         self._stop_evt = threading.Event()
         self._thread = None  # type: Optional[threading.Thread]
-        self._tmp_cfg = None  # type: Optional[tempfile.TemporaryDirectory]
 
     def _make_env(self) -> Optional[dict[str, str]]:
         env = os.environ.copy()
@@ -36,89 +33,6 @@ class ZenityWaitDialog:
         if not env.get('DISPLAY') and not env.get('WAYLAND_DISPLAY'):
             return None
 
-        # Create a temporary GTK config so zenity uses our colors.
-        # GTK3 reads: $XDG_CONFIG_HOME/gtk-3.0/gtk.css
-        self._tmp_cfg = tempfile.TemporaryDirectory(prefix='protonfixes-gtk-')
-        cfg_root = Path(self._tmp_cfg.name)
-        gtk_dir = cfg_root / 'gtk-3.0'
-        gtk_dir.mkdir(parents=True, exist_ok=True)
-
-        # Window bg: #171d25
-        # Button + progress "status bar": #292e36
-        # Text: white
-        css = """
-        window, dialog, box {
-            background-color: #171d25;
-        }
-
-        /* The outer “frame” node GTK draws for CSD windows */
-        decoration {
-        background-color: #171d25;
-        border: 1px solid #292e36;
-        box-shadow: none;
-        }
-
-        /* Titlebar / headerbar */
-        headerbar.titlebar {
-        background-color: #171d25;
-        color: #171d25;
-        border-bottom: 1px solid #292e36;
-        box-shadow: none;
-        }
-
-        headerbar.titlebar label {
-        color: #ffffff;
-        }
-
-        /* Titlebar buttons (close/min/max) – if present */
-        headerbar.titlebar button.titlebutton {
-        background-color: #292e36;
-        color: #000000;
-        border: 1px solid #292e36;
-        box-shadow: none;
-        }
-
-        headerbar.titlebar button.titlebutton:hover {
-        background-color: #292e36;
-        }
-
-        /* Labels/text */
-        label, text {
-            color: #ffffff;
-        }
-
-
-        /* Progressbar ("status bar") */
-        progressbar {
-            color: #ffffff;
-        }
-
-        progressbar trough {
-            background-color: #292e36;
-
-            /* border / outline */
-            border-color: #292e36;
-            border-style: solid;
-            border-width: 1px;
-
-            /* optional: match the flat look */
-            border-radius: 0;
-            box-shadow: none;
-        }
-
-        progressbar progress {
-            background-color: #292e36;
-            border-radius: 0;
-            box-shadow: none;
-        }
-
-        progressbar text {
-            color: #ffffff;
-        }
-        """
-        (gtk_dir / 'gtk.css').write_text(css, encoding='utf-8')
-
-        env['XDG_CONFIG_HOME'] = str(cfg_root)
         return env
 
     def _start_one(self) -> Optional[subprocess.Popen]:
@@ -197,10 +111,6 @@ class ZenityWaitDialog:
 
         if self._thread:
             self._thread.join(timeout=1.0)
-
-        if self._tmp_cfg:
-            self._tmp_cfg.cleanup()
-            self._tmp_cfg = None
 
 
 __all__ = ['ZenityWaitDialog']


### PR DESCRIPTION
- **build: update zenity-rs to 0.2.8**
- **ZenityWaitDialog: remove gtk styling, zenity-rs doesn't understand it**
- **ZenityWaitDialog: use full path to our `zenity` because the environment's PATH doesn't include it**
