### PR TITLE
gamefixes-steam: add fix for The Fruit of Grisaia

### DIFF
--- a/gamefixes-steam/345610.py
+++ b/gamefixes-steam/345610.py
@@ -1,0 +1,26 @@
+"""Game fix for The Fruit of Grisaia (345610).
+
+Fixes in-game graphics by setting ENABLE_GAMESCOPE_WSI=0 if run via gamescope.
+Note, heuristics are applied, which can be spoofed, but suffices for now as a
+robust solution for identifying gamescope would be more involved.
+"""
+
+import os
+from pathlib import Path
+
+from protonfixes import util
+
+
+def main() -> None:
+    if not os.environ.get('GAMESCOPE_WAYLAND_DISPLAY'):
+        return
+
+    # In steamrt4, pressure-vessel changes this value from gamescope-0 ->
+    # /run/pressure-vessel/gamescope-socket.
+    if not Path(os.environ['GAMESCOPE_WAYLAND_DISPLAY']).is_socket():
+        return
+
+    if os.environ.get('XDG_CURRENT_DESKTOP') != 'gamescope':
+        return
+
+    util.set_environment('ENABLE_GAMESCOPE_WSI', '0')


### PR DESCRIPTION
### Description
When running the game via gamescope, severe flickering/tearing of in-game graphics can be observed, which is triggered by navigating to menus or progressing through the text, making the game completely unplayable. To stop the flickering, besides using wined3d, set ENABLE_GAMESCOPE_WSI=0. Related to https://github.com/ValveSoftware/Proton/issues/7592.

### Expected behavior
No flickering or tearing of graphics.

#### Steps to reproduce
1. Launch the game.
2. At the menu, move the cursor around the different the menu buttons.

### Logging, screenshots, or anything else
- https://cdn.steamusercontent.com/ugc/15713458957612280817/3BF7C64E717EA678D3B0D600B52A823F3A8EC2CB/

OS: SteamOS (3.8.9)
Proton: GE-Proton11-1 (not publicly released)
