### PR TITLE
Add game fixes for several id Tech games.

### DIFF
--- a/gamefixes-gog/umu-1207659126.py
+++ b/gamefixes-gog/umu-1207659126.py
@@ -1,0 +1,9 @@
+"""Game fix for Medal of Honor: Allied Assault War Chest"""
+
+from protonfixes import util
+
+
+def main() -> None:
+    # Fix game not launching
+    util.set_environment('MESA_EXTENSION_MAX_YEAR', '2002')
+    util.set_environment('__GL_ExtensionStringVersion', '17700')

--- a/gamefixes-gog/umu-1828104558.py
+++ b/gamefixes-gog/umu-1828104558.py
@@ -3,6 +3,6 @@
 from protonfixes import util
 
 
-def early() ->  None:
+def early() -> None:
     # Fix game not launching
     util.set_environment('PROTON_OLD_GL_STRING', '1')

--- a/gamefixes-gog/umu-1828104558.py
+++ b/gamefixes-gog/umu-1828104558.py
@@ -1,0 +1,9 @@
+"""Game fix for Soldier of Fortune: Platinum Edition"""
+
+from protonfixes import util
+
+
+def main() -> None:
+    # Fix game not launching
+    util.set_environment('MESA_EXTENSION_MAX_YEAR', '2003')
+    util.set_environment('__GL_ExtensionStringVersion', '17700')

--- a/gamefixes-gog/umu-1828104558.py
+++ b/gamefixes-gog/umu-1828104558.py
@@ -3,7 +3,6 @@
 from protonfixes import util
 
 
-def main() -> None:
+def early() ->  None:
     # Fix game not launching
-    util.set_environment('MESA_EXTENSION_MAX_YEAR', '2003')
-    util.set_environment('__GL_ExtensionStringVersion', '17700')
+    util.set_environment('PROTON_OLD_GL_STRING', '1')

--- a/gamefixes-gog/umu-2310.py
+++ b/gamefixes-gog/umu-2310.py
@@ -3,10 +3,11 @@
 from protonfixes import util
 
 
-def main() -> None:
+def early() ->  None:
     # Fix game not launching when using GLQuake
-    util.set_environment('MESA_EXTENSION_MAX_YEAR', '2003')
-    util.set_environment('__GL_ExtensionStringVersion', '17700')
+    util.set_environment('PROTON_OLD_GL_STRING', '1')
+
+def main() -> None:
     # Due to legal issues the GOG version doesn't include the in-game music for WinQuake and GLQuake, but the dll used to achieve this is installed with the game
     # This dll override allows a user to have in-game music if they add their own .ogg files to the "MUSIC" folder and rename "_winmm.dll" to "winmm.dll"
     util.winedll_override('winmm', util.OverrideOrder.NATIVE_BUILTIN)

--- a/gamefixes-gog/umu-2310.py
+++ b/gamefixes-gog/umu-2310.py
@@ -1,0 +1,12 @@
+"""Game fix for Quake"""
+
+from protonfixes import util
+
+
+def main() -> None:
+    # Fix game not launching when using GLQuake
+    util.set_environment('MESA_EXTENSION_MAX_YEAR', '2003')
+    util.set_environment('__GL_ExtensionStringVersion', '17700')
+    # Due to legal issues the GOG version doesn't include the in-game music for WinQuake and GLQuake, but the dll used to achieve this is installed with the game
+    # This dll override allows a user to have in-game music if they add their own .ogg files to the "MUSIC" folder and rename "_winmm.dll" to "winmm.dll"
+    util.winedll_override('winmm', util.OverrideOrder.NATIVE_BUILTIN)

--- a/gamefixes-gog/umu-2310.py
+++ b/gamefixes-gog/umu-2310.py
@@ -3,7 +3,7 @@
 from protonfixes import util
 
 
-def early() ->  None:
+def early() -> None:
     # Fix game not launching when using GLQuake
     util.set_environment('PROTON_OLD_GL_STRING', '1')
 

--- a/gamefixes-gog/umu-2320.py
+++ b/gamefixes-gog/umu-2320.py
@@ -3,9 +3,10 @@
 from protonfixes import util
 
 
+def early() ->  None:
+    # Fix game not launching when using OpenGL
+    util.set_environment('PROTON_OLD_GL_STRING', '1')
+
 def main() -> None:
-    # Fix crash at startup when using OpenGL
-    util.set_environment('MESA_EXTENSION_MAX_YEAR', '2003')
-    util.set_environment('__GL_ExtensionStringVersion', '17700')
-	# Fix in-game music not playing
+	# Fix in-game music not playing on GOG version
     util.winedll_override('winmm', util.OverrideOrder.NATIVE_BUILTIN)

--- a/gamefixes-gog/umu-2320.py
+++ b/gamefixes-gog/umu-2320.py
@@ -3,7 +3,7 @@
 from protonfixes import util
 
 
-def early() ->  None:
+def early() -> None:
     # Fix game not launching when using OpenGL
     util.set_environment('PROTON_OLD_GL_STRING', '1')
 

--- a/gamefixes-gog/umu-6020.py
+++ b/gamefixes-gog/umu-6020.py
@@ -1,0 +1,1 @@
+../gamefixes-steam/6020.py

--- a/gamefixes-gog/umu-6030.py
+++ b/gamefixes-gog/umu-6030.py
@@ -1,0 +1,1 @@
+../gamefixes-steam/6030.py

--- a/gamefixes-gog/umu-9010.py
+++ b/gamefixes-gog/umu-9010.py
@@ -1,0 +1,1 @@
+../gamefixes-steam/9010.py

--- a/gamefixes-gog/umu-9060.py
+++ b/gamefixes-gog/umu-9060.py
@@ -3,7 +3,7 @@
 from protonfixes import util
 
 
-def early() ->  None:
+def early() -> None:
     # Fix game not launching when using OpenGL
     util.set_environment('PROTON_OLD_GL_STRING', '1')
 

--- a/gamefixes-gog/umu-9060.py
+++ b/gamefixes-gog/umu-9060.py
@@ -1,0 +1,11 @@
+"""Game fix for Hexen II"""
+
+from protonfixes import util
+
+
+def main() -> None:
+    # Fix game not launching when using OpenGL
+    util.set_environment('MESA_EXTENSION_MAX_YEAR', '2003')
+    util.set_environment('__GL_ExtensionStringVersion', '17700')
+	# Fix in-game music not playing on GOG version
+    util.winedll_override('winmm', util.OverrideOrder.NATIVE_BUILTIN)

--- a/gamefixes-gog/umu-9060.py
+++ b/gamefixes-gog/umu-9060.py
@@ -3,9 +3,10 @@
 from protonfixes import util
 
 
-def main() -> None:
+def early() ->  None:
     # Fix game not launching when using OpenGL
-    util.set_environment('MESA_EXTENSION_MAX_YEAR', '2003')
-    util.set_environment('__GL_ExtensionStringVersion', '17700')
+    util.set_environment('PROTON_OLD_GL_STRING', '1')
+
+def main() -> None:
 	# Fix in-game music not playing on GOG version
     util.winedll_override('winmm', util.OverrideOrder.NATIVE_BUILTIN)

--- a/gamefixes-steam/6020.py
+++ b/gamefixes-steam/6020.py
@@ -1,0 +1,9 @@
+"""Game fix for Star Wars Jedi Knight: Jedi Academy"""
+
+from protonfixes import util
+
+
+def main() -> None:
+    # Fix game not launching
+    util.set_environment('MESA_EXTENSION_MAX_YEAR', '2003')
+    util.set_environment('__GL_ExtensionStringVersion', '17700')

--- a/gamefixes-steam/6020.py
+++ b/gamefixes-steam/6020.py
@@ -3,6 +3,6 @@
 from protonfixes import util
 
 
-def early() ->  None:
+def early() -> None:
     # Fix game not launching
     util.set_environment('PROTON_OLD_GL_STRING', '1')

--- a/gamefixes-steam/6020.py
+++ b/gamefixes-steam/6020.py
@@ -3,7 +3,6 @@
 from protonfixes import util
 
 
-def main() -> None:
+def early() ->  None:
     # Fix game not launching
-    util.set_environment('MESA_EXTENSION_MAX_YEAR', '2003')
-    util.set_environment('__GL_ExtensionStringVersion', '17700')
+    util.set_environment('PROTON_OLD_GL_STRING', '1')

--- a/gamefixes-steam/6030.py
+++ b/gamefixes-steam/6030.py
@@ -3,6 +3,6 @@
 from protonfixes import util
 
 
-def early() ->  None:
+def early() -> None:
     # Fix game not launching
     util.set_environment('PROTON_OLD_GL_STRING', '1')

--- a/gamefixes-steam/6030.py
+++ b/gamefixes-steam/6030.py
@@ -3,7 +3,6 @@
 from protonfixes import util
 
 
-def main() -> None:
+def early() ->  None:
     # Fix game not launching
-    util.set_environment('MESA_EXTENSION_MAX_YEAR', '2003')
-    util.set_environment('__GL_ExtensionStringVersion', '17700')
+    util.set_environment('PROTON_OLD_GL_STRING', '1')

--- a/gamefixes-steam/6030.py
+++ b/gamefixes-steam/6030.py
@@ -1,0 +1,9 @@
+"""Game fix for Star Wars Jedi Knight II: Jedi Outcast"""
+
+from protonfixes import util
+
+
+def main() -> None:
+    # Fix game not launching
+    util.set_environment('MESA_EXTENSION_MAX_YEAR', '2003')
+    util.set_environment('__GL_ExtensionStringVersion', '17700')

--- a/gamefixes-steam/9010.py
+++ b/gamefixes-steam/9010.py
@@ -3,6 +3,6 @@
 from protonfixes import util
 
 
-def early() ->  None:
+def early() -> None:
     # Fix game not launching
     util.set_environment('PROTON_OLD_GL_STRING', '1')

--- a/gamefixes-steam/9010.py
+++ b/gamefixes-steam/9010.py
@@ -1,0 +1,9 @@
+"""Game fix for Return to Castle Wolfenstein"""
+
+from protonfixes import util
+
+
+def main() -> None:
+    # Fix game not launching
+    util.set_environment('MESA_EXTENSION_MAX_YEAR', '2003')
+    util.set_environment('__GL_ExtensionStringVersion', '17700')

--- a/gamefixes-steam/9010.py
+++ b/gamefixes-steam/9010.py
@@ -3,7 +3,6 @@
 from protonfixes import util
 
 
-def main() -> None:
+def early() ->  None:
     # Fix game not launching
-    util.set_environment('MESA_EXTENSION_MAX_YEAR', '2003')
-    util.set_environment('__GL_ExtensionStringVersion', '17700')
+    util.set_environment('PROTON_OLD_GL_STRING', '1')


### PR DESCRIPTION
Most id Tech 1-3 games will fail to launch on modern GPUs without an environment variable. A few other games that originally used Redbook CD audio need a dll override to use a wrapper that enables in-game music. This wrapper is exclusive to the GOG versions.

I've added fixes for the following games:
Medal of Honor: Allied Assault War Chest
Soldier of Fortune: Platinum Edition
Quake
Hexen II
Star Wars Jedi Knight: Jedi Academy
Star Wars Jedi Knight II: Jedi Outcast
Return to Castle Wolfenstein

Jedi Outcast and Jedi Academy were already on the umu-database, all other games depend on https://github.com/Open-Wine-Components/umu-database/pull/145

I tested all of the id Tech games I own on GOG. I found Quake III and Wolfenstein Enemy Territory do not need any fixes. There are a few more id Tech games on GOG that may need protonfixes that I don't own.