### PR TITLE
gamefixes-steam,gamefixes-umu,gamefixes-gog: add fix for Senren * Banka

### DIFF
--- a/gamefixes-gog/umu-1144400.py
+++ b/gamefixes-gog/umu-1144400.py
@@ -1,0 +1,1 @@
+../gamefixes-steam/1144400.py

--- a/gamefixes-steam/1144400.py
+++ b/gamefixes-steam/1144400.py
@@ -1,0 +1,8 @@
+"""Game fix for Senren*Banka"""
+
+from protonfixes import util
+
+
+def main() -> None:
+    # Fixes audio stutters for in-game videos
+    util.append_argument('-vomstyle=layer')

--- a/gamefixes-umu/umu-1144400.py
+++ b/gamefixes-umu/umu-1144400.py
@@ -1,0 +1,1 @@
+../gamefixes-steam/1144400.py


### PR DESCRIPTION
### Description
Audio stutters can be observed for the game's opening video. To fix the issue, the game engine must be configured to use a different movie renderer. Other [KiriKiri-based](https://steamdb.info/tech/Engine/KiriKiri/) games may possibly be impacted by the same issue. Similar to https://github.com/Open-Wine-Components/umu-protonfixes/pull/475, and have verified the same issue exists without the fix. Related to https://github.com/ValveSoftware/Proton/issues/5567.

### Expected behavior
No audio stutters for the opening video.

### Steps to reproduce
1. Launch the game.
2. At the menu, press the Start button.
3. Fast forward until the opening video is played.

### Logging, screenshots, or anything else
- https://cdn.steamusercontent.com/ugc/10856866699775806722/EBA9330ACCB1D9C8E84E47AFA1ABD91BC0131436/

OS: SteamOS (3.8.9)
Proton: GE-Proton11-1 (not publicly released)
