### PR TITLE
Install Verdana font for Ground Control 2

### DIFF
--- a/gamefixes-gog/umu-254840.py
+++ b/gamefixes-gog/umu-254840.py
@@ -1,0 +1,7 @@
+"""Game fix for Ground Control 2"""
+
+from protonfixes import util
+
+
+def main() -> None:
+    util.protontricks('verdana')


### PR DESCRIPTION
Reported on Heroic's Discord server: https://discord.com/channels/812703221789097985/1516510607585706064

Note that I've only added this fix for the GOG version of the game. The game is on ZOOM Platform as well & an entry was added for this game in the DB, but no subsequent fix was added here (so I assume it doesn't need it?)