### PR TITLE
gamefixes-{gog,steam}: add fix for Parquet

### DIFF
--- a/gamefixes-gog/umu-1662840.py
+++ b/gamefixes-gog/umu-1662840.py
@@ -1,0 +1,1 @@
+../gamefixes-steam/1662840.py

--- a/gamefixes-steam/1662840.py
+++ b/gamefixes-steam/1662840.py
@@ -1,0 +1,7 @@
+"""Game fix for Parquet"""
+
+from protonfixes import util
+
+
+def main() -> None:
+    util.append_argument('-vomstyle=layer')


### PR DESCRIPTION
### Description
Audio stutters and FPS degradation can be observed for the game's opening video. To fix the issue, the game engine must be configured to use a different movie renderer. Other [KiriKiri-based](https://steamdb.info/tech/Engine/KiriKiri/) games may possibly be impacted by the same issue. Similar to https://github.com/Open-Wine-Components/umu-protonfixes/pull/575. Related to https://github.com/ValveSoftware/Proton/issues/5255.

### Expected behavior
No audio stutters and consistent FPS for the opening video.

### Steps to reproduce
1. Launch the game.
2. At the menu, click the top, first button to enter the prologue.
3. Fast forward until the prologue finishes.
4. After finishing the prologue, click the second button in the menu.
5. Fast forward until the opening video is played.

### Logging, screenshots, or anything else
- https://cdn.steamusercontent.com/ugc/11277361504167155434/0013AD55408BD4E4CD9527EA93A1F4CAE5E5278E/

OS: SteamOS (3.8.10)
Proton: GE-Proton11-1 (not publicly released)
