### PR TITLE
Fixup typo in GOG OpenSSL fix

### DIFF
--- a/gamefixes-gog/default.py
+++ b/gamefixes-gog/default.py
@@ -4,4 +4,4 @@ from protonfixes import util
 
 
 def main() -> None:
-    util.set_environment('OPENSSL_ia32cap', ':~0x20000000')
+    util.set_environment('OPENSSL_ia32cap', '~0x20000000')


### PR DESCRIPTION
There was not supposed to be a leading `:` here, which made the fix do nothing

Documentation on the variable: https://docs.openssl.org/3.4/man3/OPENSSL_ia32cap/#description
Original PR adding the fix: https://github.com/Open-Wine-Components/umu-protonfixes/pull/564