### PR TITLE
gamefixes-{egs,umu}: Add fix for Elder Scrolls Online launcher

### DIFF
--- a/gamefixes-egs/umu-306130.py
+++ b/gamefixes-egs/umu-306130.py
@@ -1,0 +1,8 @@
+"""Fix for the Elder Scrolls Online"""
+
+from protonfixes import util
+
+
+def main() -> None:
+    # The launcher is a webview, it does not open correctly without webview2 installed
+    util.protontricks('webview2')

--- a/gamefixes-umu/umu-306130.py
+++ b/gamefixes-umu/umu-306130.py
@@ -1,0 +1,1 @@
+../gamefixes-egs/umu-306130.py


### PR DESCRIPTION
Log of the launcher failing:  [eso_launcher.log](https://github.com/user-attachments/files/29306034/eso_launcher.log)
Edit: Updated log with GE-Proton11-1: [launch.log](https://github.com/user-attachments/files/29397102/launch.log)

The game was apparently already added to the DB, so no PR needed there