### PR TITLE
Fix game executable mapping for Fallout New Vegas

### DIFF
--- a/gamefixes-steam/22330.py
+++ b/gamefixes-steam/22330.py
@@ -30,7 +30,7 @@ def main_with_id(game_id: str) -> None:
 def get_redirect_name(game_id: str) -> util.ReplaceType:
     """Mapping for SteamID -> script extender replacements"""
     mapping = {
-        '22380': ('FalloutNV.exe', 'nvse_loader.exe'),  # Fallout New Vegas
+        '22380': ('FalloutNVLauncher.exe', 'nvse_loader.exe'),  # Fallout New Vegas
         '22370': ('FalloutLauncher.exe', 'fose_loader.exe'),  # Fallout 3
         '377160': ('Fallout4Launcher.exe', 'f4se_loader.exe'),  # Fallout 4
         '22330': ('OblivionLauncher.exe', 'obse_loader.exe'),  # Oblivion


### PR DESCRIPTION
This PR corrects the executable mapping in gamefixes-steam/22330.py for Fallout: New Vegas so that nvse_loader.exe can launch properly.

I have tested the change and validates that it fixes the issue.

protonfixes.log will now show the following instead of the warning seen in #591:
```
ProtonFixes[25539] INFO: Changed "FalloutNVLauncher.exe" to "nvse_loader.exe"
```

Fixes #591