### PR TITLE
 Fix Conan Exiles 440900 launch

### DIFF
--- a/gamefixes-steam/440900.py
+++ b/gamefixes-steam/440900.py
@@ -8,6 +8,6 @@ def main() -> None:
     # Fixes the startup process.
     util.install_battleye_runtime()
     util.replace_command(
-        'FuncomLauncher.exe', '../ConanSandbox/Binaries/Win64/ConanSandbox.exe'
+        'FuncomLauncher.exe', '../ConanSandbox/Binaries/Win64/ConanSandbox_BE.exe'
     )
     util.append_argument('-BattlEye')


### PR DESCRIPTION
Sorry guys I know you don't like AI Slop PRs (no fan either).  I did test this though, and I had previously no clue what the issue can be. So i sat down with my Claude and we fixed this together :

The Conan Exiles protonfix redirects FuncomLauncher.exe to ../ConanSandbox/Binaries/Win64/ConanSandbox.exe, but that file no longer exists in the current install. The game process spawns, dies within ~1 second, no window ever appears.

  Current ConanSandbox/Binaries/Win64/ contents:
  - ConanSandbox_BE.exe (BattlEye wrapper)
  - ConanSandbox-Win64-Shipping.exe (UE shipping binary)
  - BattlEye/BEService_x64.exe

  No ConanSandbox.exe in that directory.

  Failure from PROTON_LOG=1:
     err:steam:run_process Failed to create process L"\"Z:\\...\\ConanSandbox\\Binaries\\Win64\\ConanSandbox.exe\" -BattlEye": 2


  (2 = ERROR_FILE_NOT_FOUND)

  Redirecting to ConanSandbox_BE.exe preserves BattlEye init (required for official servers) and still skips Funcom's launcher, which was the original intent of the fix.

  Verified: game launches normally on GE-Proton10-34 and GE-Proton11-1 after the patch. Stock Proton-Experimental doesn't run this fix (goes through FuncomLauncher.exe) so it's unaffected.

  Environment: Fedora 44, Mesa 26.1.3, AMD GPU.