### PR TITLE
add mfc42 fix for wizardry 8 steam/gog

### DIFF
--- a/gamefixes-gog/245450.py
+++ b/gamefixes-gog/245450.py
@@ -1,0 +1,1 @@
+../gamefixes-steam/245450.py

--- a/gamefixes-steam/245450.py
+++ b/gamefixes-steam/245450.py
@@ -1,0 +1,8 @@
+"""Game fix for Wizardry 8"""
+
+from protonfixes import util
+
+
+def main() -> None:
+    """Needs mfc42 for settings dialog functionality"""
+    util.protontricks('mfc42')


### PR DESCRIPTION
Wizardry 8 needs mfc42 for the settings dialog to launch.

Tested/confirmed with proton11-cachyos.

xref: https://github.com/Open-Wine-Components/umu-database/pull/149