### PR TITLE
Borderlands3 (397540) SDK patch

### DIFF
--- a/gamefixes-steam/397540.py
+++ b/gamefixes-steam/397540.py
@@ -7,3 +7,5 @@ def main() -> None:
     """Borderlands 3"""
     # Fixes the startup process.
     util.protontricks('d3dcompiler_47')
+    # Fixes crash with BL SDK
+    util.protontricks('vcrun2022')


### PR DESCRIPTION
As discussed here https://github.com/bl-sdk/oak-mod-manager/issues/69 recent version of SDK crashes the main game.
This is a proposal to fix this so people don't need to troubleshoot it themselves.