### PR TITLE
Add game fix for Zero Escape: Zero Time Dilemma

### DIFF
--- a/gamefixes-steam/311240.py
+++ b/gamefixes-steam/311240.py
@@ -1,0 +1,7 @@
+"""Game fix for Zero Escape: Zero Time Dilemma"""
+
+from protonfixes import util
+
+def main() -> None:
+    """Disables libglesv2 to allow launcher to render ""
+    util.winedll_override('libglesv2', OverrideOrder.DISABLED)


### PR DESCRIPTION
Launcher was made with electron for unholy reasons mankind was not meant to understand, this allows it to render.