### PR TITLE
Disable NTSync for AC Black Flag Resynced

### DIFF
--- a/gamefixes-steam/3751950.py
+++ b/gamefixes-steam/3751950.py
@@ -1,0 +1,8 @@
+"""Assassin's Creed: Black Flag Resynced"""
+
+from protonfixes import util
+
+
+def main() -> None:
+    """Works around a regression in Proton 11, which is causing the game to crash unless NTSync is disabled."""
+    util.disable_ntsync()


### PR DESCRIPTION
Apparently Proton 11 has a regression causing the game to not start unless NTSync is disabled.

ValveSoftware/Proton#9958