### PR TITLE
heroesofnewerthreborn: add d3dcompiler_47

### DIFF
--- a/gamefixes-umu/umu-heroesofnewerthreborn.py
+++ b/gamefixes-umu/umu-heroesofnewerthreborn.py
@@ -7,3 +7,6 @@ def main() -> None:
     util.protontricks('gdiplus')
     util.protontricks('corefonts')
     util.protontricks('ie8')
+    # Fixes effects rendering solid black. The game compiles shaders at
+    # runtime and vkd3d-shader's HLSL compiler lacks reversebits.
+    util.protontricks('d3dcompiler_47')


### PR DESCRIPTION
The game compiles its shaders at runtime with D3DCompile (ps_5_0). Wine's d3dcompiler_47 routes to vkd3d-shader, whose HLSL intrinsic table has countbits, firstbithigh and firstbitlow but not reversebits, so pbr_reference permutations fail to compile:

```
Compiling pixel shader: pbr_reference.meshvn1ta.color.793.psh (ps_5_0)
:66:69: E5005: Function "reversebits" is not defined.
:284:38: E5000: Failed to evaluate constant expression.
:284:38: E5008: Array size is not a positive integer constant.
```

The engine substitutes its own error_diffuse_black.node fallback, so affected geometry renders solid black. In game this appears as black blobs where the water splash effects should be.

Installing native d3dcompiler_47 resolves it. Verified on GE-Proton11-3.
