### PR TITLE
Add CPU core limit for LEGO Marvel Super Heroes 2

### DIFF
--- a/gamefixes-steam/647830.py
+++ b/gamefixes-steam/647830.py
@@ -1,0 +1,8 @@
+"""LEGO® Marvel Super Heroes 2"""
+
+from protonfixes import util
+
+
+def main() -> None:
+    """Arena mode is unstable and likely to crash with more than 4 cores."""
+    util.set_cpu_topology_limit(4)


### PR DESCRIPTION
Game's arena mode is unstable above 4 cores, so limit it to 4. 

https://steamcommunity.com/sharedfiles/filedetails/?id=2908629829