### PR TITLE
update fix for dungeon town

### DIFF
--- a/gamefixes-steam/959880.py
+++ b/gamefixes-steam/959880.py
@@ -1,57 +1,25 @@
 """Game fix for Dungeon Town.
 
-The game loads its bundled fonts but requests two of them by PostScript name.
-Install the NewRodin face that the game does not load itself, then alias both
-PostScript names to the family names used by Wine.
+The game loads Source Han Sans but requests it by PostScript name. Alias that
+name to the family name used by Wine. Force Wine's font-name selection to use
+its English fallback because regional English locales can discard the Japanese
+family aliases embedded in the game's other fonts.
 """
 
-import shutil
-from pathlib import Path
-
 from protonfixes import util
-from protonfixes.logger import log
 
 
-FONT_KEYS = (
-    'HKLM\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Fonts',
-    'HKLM\\Software\\Microsoft\\Windows\\CurrentVersion\\Fonts',
-)
 FONT_SUBSTITUTES_KEY = (
     'HKLM\\Software\\Microsoft\\Windows NT\\CurrentVersion\\FontSubstitutes'
 )
 
 
-def install_new_rodin() -> None:
-    """Install the bundled NewRodin face that the game does not load."""
-    font_name = 'FOT-NewRodinPro-DB.otf'
-    source = Path(util.get_game_install_path()) / 'font' / font_name
-    destination = util.protonprefix() / 'drive_c/windows/Fonts' / font_name
-
-    if not source.is_file():
-        log.warn(f'Could not find bundled font: {source}')
-        return
-
-    destination.parent.mkdir(parents=True, exist_ok=True)
-    if not destination.is_file():
-        log.info(f'Installing bundled font: {font_name}')
-        shutil.copy2(source, destination)
-
-    for key in FONT_KEYS:
-        util.regedit_add(key, 'NewRodinPro-DB', 'REG_SZ', font_name, arch=True)
-
-
 def main() -> None:
-    install_new_rodin()
-
-    substitutions = {
-        'NewRodinPro-DB': 'FOT-NewRodin Pro DB',
-        'SourceHanSans-Medium': 'Source Han Sans Medium',
-    }
-    for postscript_name, family_name in substitutions.items():
-        util.regedit_add(
-            FONT_SUBSTITUTES_KEY,
-            postscript_name,
-            'REG_SZ',
-            family_name,
-            arch=True,
-        )
+    util.set_environment('LC_ALL', 'C.UTF-8')
+    util.regedit_add(
+        FONT_SUBSTITUTES_KEY,
+        'SourceHanSans-Medium',
+        'REG_SZ',
+        'Source Han Sans Medium',
+        arch=True,
+    )


### PR DESCRIPTION
I did more testing with this game, in my testing the new rodin font isn't being used by the game, so I removed this override. I also added `LC_ALL=C.UTF-8` because it appears there is a wine bug with regional English locales (with the exception of en_US) that is what is causing the fonts to fail to load.

My system (en_US.UTF-8):
```
parsed font name: FOT-UD角ゴC80 Pro DB
requested font name: FOT-UD角ゴC80 Pro DB
wine substitutes: FOT-UDKakugoC80 Pro DB
```
Someone else (en_CA.UTF-8):
```
parsed font name: FOT-UDKakugoC80 Pro
requested font name: FOT-UD角ゴC80 Pro DB 
fallback: Courier New
```

Source Han Sans Medium still needs the font override, that font fails to be loaded even with this change on all systems for me it falls back to Liberation Mono.

Worth noting that this game still needs a custom wine build with [this patch](https://gitlab.winehq.org/wine/wine/-/merge_requests/10603) for fonts to not be huge.
